### PR TITLE
Tighten charcoal-copper design system for consistent modern UI

### DIFF
--- a/app/expert-tips/page.tsx
+++ b/app/expert-tips/page.tsx
@@ -40,7 +40,7 @@ async function TipsGrid() {
 						key={post.slug}
 					>
 						<Link
-							className="relative block aspect-[16/9] overflow-hidden bg-muted"
+							className="bg-muted relative block aspect-[16/9] overflow-hidden"
 							href={`/${post.slug}` as Route}
 							prefetch
 							tabIndex={-1}
@@ -60,7 +60,7 @@ async function TipsGrid() {
 							<Badge className="w-fit" tone="muted">
 								{post.category ?? "Expert Tips"}
 							</Badge>
-							<CardTitle className="mt-3 group-hover:text-primary">
+							<CardTitle className="group-hover:text-primary mt-3">
 								<Link href={`/${post.slug}` as Route} prefetch>
 									{post.title}
 								</Link>
@@ -69,13 +69,13 @@ async function TipsGrid() {
 						</CardHeader>
 						<CardContent className="mt-auto">
 							{post.date ? (
-								<p className="mb-4 flex items-center gap-2 text-xs font-bold text-muted-foreground">
-									<CalendarDays className="size-4 text-primary" />
+								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
+									<CalendarDays className="text-primary size-4" />
 									{post.date}
 								</p>
 							) : null}
 							<Link
-								className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
+								className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
 								href={`/${post.slug}` as Route}
 								prefetch
 							>

--- a/app/expert-tips/page.tsx
+++ b/app/expert-tips/page.tsx
@@ -32,7 +32,7 @@ async function TipsGrid() {
 	const posts = await getCollection("posts")
 
 	return (
-		<section className="mx-auto max-w-7xl px-4 py-16 md:px-8 lg:py-20">
+		<section className="container-shell section-y">
 			<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
 				{posts.map((post) => (
 					<Card
@@ -40,7 +40,7 @@ async function TipsGrid() {
 						key={post.slug}
 					>
 						<Link
-							className="relative block aspect-[16/9] overflow-hidden bg-neutral-100"
+							className="relative block aspect-[16/9] overflow-hidden bg-muted"
 							href={`/${post.slug}` as Route}
 							prefetch
 							tabIndex={-1}
@@ -57,8 +57,10 @@ async function TipsGrid() {
 							/>
 						</Link>
 						<CardHeader>
-							<Badge className="w-fit">{post.category ?? "Expert Tips"}</Badge>
-							<CardTitle className="group-hover:text-primary mt-3">
+							<Badge className="w-fit" tone="muted">
+								{post.category ?? "Expert Tips"}
+							</Badge>
+							<CardTitle className="mt-3 group-hover:text-primary">
 								<Link href={`/${post.slug}` as Route} prefetch>
 									{post.title}
 								</Link>
@@ -67,13 +69,13 @@ async function TipsGrid() {
 						</CardHeader>
 						<CardContent className="mt-auto">
 							{post.date ? (
-								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
-									<CalendarDays className="text-primary size-4" />
+								<p className="mb-4 flex items-center gap-2 text-xs font-bold text-muted-foreground">
+									<CalendarDays className="size-4 text-primary" />
 									{post.date}
 								</p>
 							) : null}
 							<Link
-								className="text-primary inline-flex items-center gap-2 text-sm font-black"
+								className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
 								href={`/${post.slug}` as Route}
 								prefetch
 							>
@@ -101,7 +103,7 @@ export default function ExpertTipsPage() {
 
 			<Suspense
 				fallback={
-					<section className="mx-auto max-w-7xl px-4 py-16 md:px-8">
+					<section className="container-shell section-y">
 						Loading guides…
 					</section>
 				}

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,39 +20,60 @@
 	--color-border: var(--border);
 	--color-input: var(--input);
 	--color-ring: var(--ring);
+	--color-ink: var(--ink);
+	--color-ink-soft: var(--ink-soft);
+	--color-panel: var(--panel);
+	--color-panel-elevated: var(--panel-elevated);
 	--font-sans: var(--font-sans);
-	--radius-sm: calc(var(--radius) - 4px);
-	--radius-md: calc(var(--radius) - 2px);
-	--radius-lg: var(--radius);
-	--radius-xl: calc(var(--radius) + 4px);
+	--radius-sm: calc(var(--radius) - 2px);
+	--radius-md: var(--radius);
+	--radius-lg: calc(var(--radius) + 2px);
+	--radius-xl: calc(var(--radius) + 6px);
 	--animate-accordion-down: accordion-down 0.2s ease-out;
 	--animate-accordion-up: accordion-up 0.2s ease-out;
+	--animate-rise: rise 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+	--animate-fade: fade 0.55s ease-out both;
 }
 
+/*
+  Wade's design system
+  Charcoal + copper. Cool stone neutrals. Sharp geometry.
+  No cream wash, no purple, no glow stacks, no pill clusters.
+*/
 :root {
-	--background: #ffffff;
-	--foreground: #111111;
+	--ink: #101214;
+	--ink-soft: #1a1d21;
+	--panel: #101214;
+	--panel-elevated: #1c2025;
+	--background: #f7f7f5;
+	--foreground: #141618;
 	--card: #ffffff;
-	--card-foreground: #111111;
+	--card-foreground: #141618;
 	--popover: #ffffff;
-	--popover-foreground: #111111;
+	--popover-foreground: #141618;
 	--primary: #8f4a1a;
 	--primary-foreground: #ffffff;
-	--primary-bright: #e3a15f;
-	--secondary: #f5f3ef;
-	--secondary-foreground: #231f1b;
-	--muted: #f5f5f4;
-	--muted-foreground: #68645f;
-	--accent: #f3e7dd;
-	--accent-foreground: #6f3c16;
-	--destructive: #dc2626;
-	--border: #e7e5e4;
-	--input: #e7e5e4;
-	--ring: #bc6f30;
-	--radius: 0.625rem;
+	--primary-bright: #e0a15d;
+	--secondary: #ececea;
+	--secondary-foreground: #1c1f23;
+	--muted: #efefed;
+	--muted-foreground: #5c6168;
+	--accent: #efe4d8;
+	--accent-foreground: #6b3a14;
+	--destructive: #c2410c;
+	--border: #dddcd7;
+	--input: #dddcd7;
+	--ring: #8f4a1a;
+	--radius: 0.5rem;
+	--shadow-edge: 0 0 0 1px color-mix(in srgb, var(--ink) 8%, transparent);
 	--font-sans:
-		var(--font-manrope), "Segoe UI", Helvetica, sans-serif, "Apple Color Emoji",
-		"Segoe UI Emoji";
+		var(--font-manrope), "Avenir Next", "Segoe UI", Helvetica, sans-serif;
+	--space-page-x: clamp(1rem, 3vw, 2rem);
+	--space-section-y: clamp(3.5rem, 7vw, 5.5rem);
+	--content-max: 80rem;
+	--type-display: clamp(2.75rem, 6vw, 4.5rem);
+	--type-title: clamp(1.85rem, 3.2vw, 2.75rem);
+	--type-lead: clamp(1.05rem, 1.5vw, 1.2rem);
 }
 
 * {
@@ -66,14 +87,27 @@ html {
 
 body {
 	margin: 0;
-	background: var(--background);
+	background:
+		radial-gradient(
+			1200px 500px at 10% -10%,
+			color-mix(in srgb, var(--primary) 8%, transparent),
+			transparent 55%
+		),
+		radial-gradient(
+			900px 420px at 100% 0%,
+			color-mix(in srgb, var(--ink) 5%, transparent),
+			transparent 50%
+		),
+		var(--background);
 	color: var(--foreground);
 	font-family: var(--font-sans);
+	font-feature-settings: "ss01" on, "kern" on;
 	-webkit-font-smoothing: antialiased;
 }
 
 ::selection {
-	background: color-mix(in srgb, var(--primary) 28%, transparent);
+	background: color-mix(in srgb, var(--primary) 30%, transparent);
+	color: var(--foreground);
 }
 
 a,
@@ -88,13 +122,123 @@ summary {
 	cursor: pointer;
 }
 
+/* ——— Layout ——— */
 .container-shell {
-	width: min(100% - 2rem, 80rem);
+	width: min(100% - (var(--space-page-x) * 2), var(--content-max));
 	margin-inline: auto;
 }
 
+.section-y {
+	padding-block: var(--space-section-y);
+}
+
+.surface-dark {
+	background:
+		radial-gradient(
+			800px 360px at 85% -20%,
+			color-mix(in srgb, var(--primary-bright) 16%, transparent),
+			transparent 60%
+		),
+		var(--panel);
+	color: #f4f4f2;
+}
+
+.surface-dark-soft {
+	background: var(--ink-soft);
+	color: #f4f4f2;
+}
+
+.surface-panel {
+	background: var(--card);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-edge);
+}
+
+/* ——— Type ——— */
+.type-eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.72rem;
+	font-weight: 800;
+	letter-spacing: 0.16em;
+	text-transform: uppercase;
+	color: var(--primary);
+}
+
+.surface-dark .type-eyebrow,
+.surface-dark-soft .type-eyebrow {
+	color: var(--primary-bright);
+}
+
+.type-display {
+	font-size: var(--type-display);
+	font-weight: 800;
+	line-height: 0.95;
+	letter-spacing: -0.045em;
+	text-wrap: balance;
+}
+
+.type-title {
+	font-size: var(--type-title);
+	font-weight: 800;
+	line-height: 1.05;
+	letter-spacing: -0.035em;
+	text-wrap: balance;
+}
+
+.type-lead {
+	font-size: var(--type-lead);
+	line-height: 1.65;
+	color: var(--muted-foreground);
+}
+
+.surface-dark .type-lead,
+.surface-dark-soft .type-lead {
+	color: #d4d4d0;
+}
+
+/* ——— Motion ——— */
+@keyframes rise {
+	from {
+		opacity: 0;
+		transform: translateY(14px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes fade {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+.motion-rise {
+	animation: var(--animate-rise);
+}
+
+.motion-fade {
+	animation: var(--animate-fade);
+}
+
+.motion-delay-1 {
+	animation-delay: 90ms;
+}
+
+.motion-delay-2 {
+	animation-delay: 180ms;
+}
+
+/* ——— Prose ——— */
 .prose {
-	color: #44403c;
+	color: #3f444b;
 	font-size: 1.0625rem;
 	line-height: 1.8;
 }
@@ -106,21 +250,21 @@ summary {
 .prose h2,
 .prose h3,
 .prose h4 {
-	color: #171717;
-	font-weight: 850;
-	line-height: 1.2;
-	letter-spacing: -0.025em;
+	color: var(--foreground);
+	font-weight: 800;
+	line-height: 1.15;
+	letter-spacing: -0.03em;
 	scroll-margin-top: 7rem;
 }
 
 .prose h2 {
 	margin-top: 2.25em;
-	font-size: clamp(1.7rem, 3vw, 2.15rem);
+	font-size: clamp(1.65rem, 2.8vw, 2rem);
 }
 
 .prose h3 {
-	margin-top: 1.8em;
-	font-size: 1.4rem;
+	margin-top: 1.75em;
+	font-size: 1.3rem;
 }
 
 .prose a {
@@ -128,11 +272,12 @@ summary {
 	font-weight: 700;
 	text-decoration: underline;
 	text-underline-offset: 3px;
+	text-decoration-thickness: 1.5px;
 }
 
 .prose ul,
 .prose ol {
-	padding-left: 1.35rem;
+	padding-left: 1.3rem;
 }
 
 .prose ul {
@@ -144,22 +289,21 @@ summary {
 }
 
 .prose li + li {
-	margin-top: 0.5rem;
+	margin-top: 0.45rem;
 }
 
 .prose blockquote {
-	border-left: 4px solid var(--primary);
-	border-radius: 0 0.75rem 0.75rem 0;
-	background: #faf8f6;
-	padding: 1rem 1.25rem;
-	color: #57534e;
+	border-left: 3px solid var(--primary);
+	background: color-mix(in srgb, var(--secondary) 70%, white);
+	padding: 1rem 1.2rem;
+	color: #4b5158;
 }
 
 .prose table {
 	width: 100%;
 	border-collapse: collapse;
 	overflow: hidden;
-	border-radius: 0.75rem;
+	border-radius: var(--radius-md);
 }
 
 .prose th,
@@ -171,7 +315,8 @@ summary {
 
 .prose th {
 	background: var(--secondary);
-	color: #292524;
+	color: var(--foreground);
+	font-weight: 800;
 }
 
 @keyframes accordion-down {

--- a/app/globals.css
+++ b/app/globals.css
@@ -101,7 +101,9 @@ body {
 		var(--background);
 	color: var(--foreground);
 	font-family: var(--font-sans);
-	font-feature-settings: "ss01" on, "kern" on;
+	font-feature-settings:
+		"ss01" on,
+		"kern" on;
 	-webkit-font-smoothing: antialiased;
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -74,7 +74,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
 	width: "device-width",
 	initialScale: 1,
-	themeColor: "#111111",
+	themeColor: "#101214",
 }
 
 const localBusinessSchema = {

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -11,13 +11,9 @@ export default function NotFound() {
 			id="main-content"
 		>
 			<div className="max-w-xl text-center">
-				<p className="text-primary text-sm font-black tracking-[0.18em] uppercase">
-					404
-				</p>
-				<h1 className="mt-4 text-5xl font-black tracking-tight">
-					This page could not be found.
-				</h1>
-				<p className="text-muted-foreground mt-5 leading-relaxed">
+				<p className="type-eyebrow justify-center">404</p>
+				<h1 className="type-display mt-4">This page could not be found.</h1>
+				<p className="type-lead mt-5">
 					The page may have moved during our website upgrade. Use the links
 					below or call us and we will point you in the right direction.
 				</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -149,10 +149,10 @@ export default function HomePage() {
 					sizes="100vw"
 					src="/images/work/engineered-septic-hero.webp"
 				/>
-				<div className="absolute inset-0 bg-linear-to-r from-ink via-ink/88 to-ink/45" />
-				<div className="absolute inset-0 bg-linear-to-t from-ink/80 via-transparent to-ink/35" />
+				<div className="from-ink via-ink/88 to-ink/45 absolute inset-0 bg-linear-to-r" />
+				<div className="from-ink/80 to-ink/35 absolute inset-0 bg-linear-to-t via-transparent" />
 
-				<div className="container-shell relative flex min-h-[min(92vh,52rem)] flex-col justify-end pb-16 pt-28 lg:justify-center lg:pb-24 lg:pt-20">
+				<div className="container-shell relative flex min-h-[min(92vh,52rem)] flex-col justify-end pt-28 pb-16 lg:justify-center lg:pt-20 lg:pb-24">
 					<div className="max-w-3xl">
 						<p className="type-eyebrow motion-fade text-primary-bright">
 							Wade&apos;s Plumbing &amp; Septic
@@ -190,8 +190,8 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-b border-border bg-card">
-				<div className="container-shell grid grid-cols-2 gap-4 py-5 text-sm font-bold text-muted-foreground md:grid-cols-4">
+			<section className="border-border bg-card border-b">
+				<div className="container-shell text-muted-foreground grid grid-cols-2 gap-4 py-5 text-sm font-bold md:grid-cols-4">
 					{[
 						"Family Owned & Operated",
 						"Licensed & Insured",
@@ -199,7 +199,7 @@ export default function HomePage() {
 						"★★★★★ 4.9 Local Rating",
 					].map((item) => (
 						<span className="flex items-center justify-center gap-2" key={item}>
-							<BadgeCheck className="size-4 shrink-0 text-primary" />
+							<BadgeCheck className="text-primary size-4 shrink-0" />
 							{item}
 						</span>
 					))}
@@ -245,13 +245,13 @@ export default function HomePage() {
 								},
 							].map(({ icon: Icon, title, text }) => (
 								<div className="surface-panel p-5" key={title}>
-									<span className="grid size-10 place-items-center rounded-md bg-accent text-accent-foreground">
+									<span className="bg-accent text-accent-foreground grid size-10 place-items-center rounded-md">
 										<Icon className="size-5" />
 									</span>
 									<h3 className="mt-4 text-lg font-extrabold tracking-[-0.02em]">
 										{title}
 									</h3>
-									<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+									<p className="text-muted-foreground mt-2 text-sm leading-relaxed">
 										{text}
 									</p>
 								</div>
@@ -306,7 +306,7 @@ export default function HomePage() {
 					<div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 						{workGallery.map((image) => (
 							<figure key={image.src}>
-								<div className="relative aspect-[4/5] overflow-hidden rounded-lg bg-panel-elevated">
+								<div className="bg-panel-elevated relative aspect-[4/5] overflow-hidden rounded-lg">
 									<Image
 										alt={image.alt}
 										className="object-cover"
@@ -330,7 +330,9 @@ export default function HomePage() {
 					<div className="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
 						<div className="max-w-2xl">
 							<Badge>What We Do</Badge>
-							<h2 className="type-title mt-5">Plumbing &amp; septic services</h2>
+							<h2 className="type-title mt-5">
+								Plumbing &amp; septic services
+							</h2>
 							<p className="type-lead mt-4">
 								From routine maintenance to complex installations, our licensed
 								team handles it cleanly, honestly, and on time.
@@ -363,10 +365,10 @@ export default function HomePage() {
 									<CardDescription>{group.description}</CardDescription>
 								</CardHeader>
 								<CardContent>
-									<ul className="space-y-2 text-sm text-muted-foreground">
+									<ul className="text-muted-foreground space-y-2 text-sm">
 										{group.items.map((item) => (
 											<li className="flex items-center gap-2" key={item}>
-												<Check className="size-4 text-primary" />
+												<Check className="text-primary size-4" />
 												{item}
 											</li>
 										))}
@@ -378,9 +380,9 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-y border-border bg-card py-12">
+			<section className="border-border bg-card border-y py-12">
 				<div className="container-shell">
-					<p className="text-center text-xs font-extrabold tracking-[0.16em] text-muted-foreground uppercase">
+					<p className="text-muted-foreground text-center text-xs font-extrabold tracking-[0.16em] uppercase">
 						Experienced with leading plumbing equipment brands
 					</p>
 					<div className="mt-8 grid grid-cols-2 items-center gap-8 sm:grid-cols-3 lg:grid-cols-5">
@@ -426,11 +428,11 @@ export default function HomePage() {
 								],
 							].map(([title, text]) => (
 								<div className="surface-panel p-5" key={title}>
-									<Wrench className="size-5 text-primary" />
+									<Wrench className="text-primary size-5" />
 									<h3 className="mt-3 font-extrabold tracking-[-0.02em]">
 										{title}
 									</h3>
-									<p className="mt-1 text-sm text-muted-foreground">{text}</p>
+									<p className="text-muted-foreground mt-1 text-sm">{text}</p>
 								</div>
 							))}
 						</div>
@@ -479,7 +481,7 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="section-y border-y border-border bg-secondary/60">
+			<section className="section-y border-border bg-secondary/60 border-y">
 				<div className="container-shell grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
 					<div>
 						<Badge>Frequently Asked Questions</Badge>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,12 +37,6 @@ export const metadata: Metadata = buildPageMetadata({
 	image: "/images/locations/santa-cruz-plumber.webp",
 })
 
-const trustItems = [
-	"Licensed & insured",
-	"Flat-rate pricing",
-	"Satisfaction guaranteed",
-]
-
 const serviceGroups = [
 	{
 		title: "Residential Plumbing",
@@ -144,35 +138,35 @@ const faqs = [
 export default function HomePage() {
 	return (
 		<main id="main-content">
-			<section className="relative overflow-hidden bg-[#111] text-white">
-				<div className="bg-primary/12 pointer-events-none absolute -top-48 -right-40 size-[38rem] rounded-full blur-3xl" />
-				<div className="mx-auto grid max-w-7xl items-center gap-12 px-4 py-16 md:px-8 lg:grid-cols-2 lg:gap-16 lg:py-24">
-					<div className="relative z-10">
-						<Badge className="border-primary-bright/40 bg-primary-bright/15 text-primary-bright mb-6">
-							<span className="bg-primary-bright mr-2 size-1.5 rounded-full" />
-							{siteConfig.serviceArea}
-						</Badge>
-						<h1 className="text-5xl leading-[0.95] font-black tracking-[-0.055em] sm:text-6xl lg:text-7xl">
-							Honest
-							<br />
-							Plumbing
-							<br />
-							<span className="text-primary-bright">&amp; Septic</span>
-						</h1>
-						<p className="mt-7 max-w-xl text-lg leading-relaxed text-neutral-200">
-							No sales pressure. No upselling. Quality workmanship from local
-							professionals you can count on—with clear pricing before work
-							begins.
+			<section className="surface-dark relative min-h-[min(92vh,52rem)] overflow-hidden">
+				<Image
+					alt="Three-tank engineered septic system installed on a hillside property in Santa Cruz County"
+					className="object-cover object-center"
+					fill
+					fetchPriority="high"
+					priority
+					quality={70}
+					sizes="100vw"
+					src="/images/work/engineered-septic-hero.webp"
+				/>
+				<div className="absolute inset-0 bg-linear-to-r from-ink via-ink/88 to-ink/45" />
+				<div className="absolute inset-0 bg-linear-to-t from-ink/80 via-transparent to-ink/35" />
+
+				<div className="container-shell relative flex min-h-[min(92vh,52rem)] flex-col justify-end pb-16 pt-28 lg:justify-center lg:pb-24 lg:pt-20">
+					<div className="max-w-3xl">
+						<p className="type-eyebrow motion-fade text-primary-bright">
+							Wade&apos;s Plumbing &amp; Septic
 						</p>
-						<div className="mt-7 grid gap-3 text-sm text-neutral-200 sm:grid-cols-3">
-							{trustItems.map((item) => (
-								<span className="flex items-center gap-2" key={item}>
-									<Check className="text-primary-bright size-4 shrink-0" />
-									{item}
-								</span>
-							))}
-						</div>
-						<div className="mt-8 flex flex-col gap-3 sm:flex-row">
+						<h1 className="type-display motion-rise mt-5 text-white">
+							Honest plumbing
+							<br />
+							<span className="text-primary-bright">&amp; septic</span>
+						</h1>
+						<p className="type-lead motion-rise motion-delay-1 mt-6 max-w-xl">
+							No sales pressure. No upselling. Clear pricing before work begins
+							from local licensed professionals.
+						</p>
+						<div className="motion-rise motion-delay-2 mt-8 flex flex-col gap-3 sm:flex-row">
 							<a
 								className={cn(buttonVariants({ size: "xl" }), "gap-2.5")}
 								href={siteConfig.phoneHref}
@@ -192,63 +186,12 @@ export default function HomePage() {
 								<ArrowRight />
 							</Link>
 						</div>
-						<div className="mt-8 flex items-center gap-3 border-t border-white/10 pt-6 text-sm text-neutral-200">
-							<span className="text-amber-300" aria-label="5 stars">
-								★★★★★
-							</span>
-							<span>4.9 local reputation · Family owned since 2021</span>
-						</div>
-					</div>
-
-					<div className="relative hidden h-[32.5rem] items-end gap-4 lg:flex">
-						<div className="relative h-full flex-1 overflow-hidden rounded-2xl shadow-2xl shadow-black/40">
-							<Image
-								alt="Three-tank engineered septic system installed on a hillside property in Santa Cruz County"
-								className="object-cover"
-								fill
-								fetchPriority="high"
-								priority
-								quality={65}
-								sizes="(min-width: 1024px) 38vw, 1px"
-								src="/images/work/engineered-septic-hero.webp"
-							/>
-							<div className="absolute inset-0 bg-linear-to-t from-black/55 via-transparent to-transparent" />
-						</div>
-						<div className="flex w-44 shrink-0 flex-col gap-4">
-							<div className="relative h-56 overflow-hidden rounded-2xl shadow-xl">
-								<Image
-									alt="Tankless water heater installation"
-									className="object-cover"
-									fill
-									quality={75}
-									sizes="176px"
-									src="/images/work/tankless-water-heater-installation.webp"
-								/>
-							</div>
-							<div className="relative h-56 overflow-hidden rounded-2xl shadow-xl">
-								<Image
-									alt="Precision plumbing valve installation"
-									className="object-cover"
-									fill
-									quality={75}
-									sizes="176px"
-									src="/images/work/precision-valve-installation.webp"
-								/>
-							</div>
-						</div>
-						<div className="absolute top-6 left-6 rounded-xl border border-white/20 bg-black/30 px-4 py-3 backdrop-blur-md">
-							<p className="text-xs text-neutral-300">Serving</p>
-							<p className="text-sm font-black">California + Georgia</p>
-							<p className="text-primary-bright text-xs font-bold">
-								Santa Cruz · Santa Clara · Pickens
-							</p>
-						</div>
 					</div>
 				</div>
 			</section>
 
-			<section className="border-b bg-white">
-				<div className="mx-auto grid max-w-7xl grid-cols-2 gap-4 px-4 py-5 text-sm font-bold text-neutral-600 md:grid-cols-4 md:px-8">
+			<section className="border-b border-border bg-card">
+				<div className="container-shell grid grid-cols-2 gap-4 py-5 text-sm font-bold text-muted-foreground md:grid-cols-4">
 					{[
 						"Family Owned & Operated",
 						"Licensed & Insured",
@@ -256,21 +199,21 @@ export default function HomePage() {
 						"★★★★★ 4.9 Local Rating",
 					].map((item) => (
 						<span className="flex items-center justify-center gap-2" key={item}>
-							<BadgeCheck className="text-primary size-4 shrink-0" />
+							<BadgeCheck className="size-4 shrink-0 text-primary" />
 							{item}
 						</span>
 					))}
 				</div>
 			</section>
 
-			<section className="py-20">
-				<div className="mx-auto max-w-7xl px-4 md:px-8">
+			<section className="section-y">
+				<div className="container-shell">
 					<div className="mx-auto max-w-3xl text-center">
 						<Badge>Our Core Specialty</Badge>
-						<h2 className="mt-5 text-4xl font-black tracking-tight sm:text-5xl">
-							Engineered <span className="text-primary">Septic Systems</span>
+						<h2 className="type-title mt-5">
+							Engineered <span className="text-primary">septic systems</span>
 						</h2>
-						<p className="text-muted-foreground mt-5 text-lg leading-relaxed">
+						<p className="type-lead mt-5">
 							When a standard system will not work—steep slopes, difficult soil,
 							tight lots, or sensitive environments—that is exactly where we
 							excel.
@@ -301,15 +244,17 @@ export default function HomePage() {
 									text: "We tell you what can work before money changes hands.",
 								},
 							].map(({ icon: Icon, title, text }) => (
-								<Card className="bg-neutral-50 shadow-none" key={title}>
-									<CardHeader>
-										<span className="bg-primary/10 text-primary grid size-10 place-items-center rounded-xl">
-											<Icon className="size-5" />
-										</span>
-										<CardTitle className="mt-3 text-lg">{title}</CardTitle>
-										<CardDescription>{text}</CardDescription>
-									</CardHeader>
-								</Card>
+								<div className="surface-panel p-5" key={title}>
+									<span className="grid size-10 place-items-center rounded-md bg-accent text-accent-foreground">
+										<Icon className="size-5" />
+									</span>
+									<h3 className="mt-4 text-lg font-extrabold tracking-[-0.02em]">
+										{title}
+									</h3>
+									<p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+										{text}
+									</p>
+								</div>
 							))}
 							<a
 								className={cn(
@@ -322,7 +267,7 @@ export default function HomePage() {
 								Call to Schedule — {siteConfig.phone}
 							</a>
 						</div>
-						<div className="relative aspect-[4/3] overflow-hidden rounded-3xl">
+						<div className="relative aspect-[4/3] overflow-hidden rounded-lg">
 							<Image
 								alt="Three-tank septic system installation on hillside property"
 								className="object-cover"
@@ -336,17 +281,15 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-y bg-[#111] py-20 text-white">
-				<div className="mx-auto max-w-7xl px-4 md:px-8">
+			<section className="surface-dark section-y">
+				<div className="container-shell">
 					<div className="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
 						<div className="max-w-2xl">
-							<Badge className="border-primary-bright/40 bg-primary-bright/15 text-primary-bright">
-								Project Gallery
-							</Badge>
-							<h2 className="mt-5 text-4xl font-black tracking-tight">
+							<Badge tone="inverse">Project Gallery</Badge>
+							<h2 className="type-title mt-5 text-white">
 								Real work from the Wade&apos;s team.
 							</h2>
-							<p className="mt-4 text-lg text-neutral-300">
+							<p className="type-lead mt-4">
 								Engineered septic installations, excavation, controls, and
 								finished systems completed on challenging Santa Cruz County
 								properties.
@@ -363,7 +306,7 @@ export default function HomePage() {
 					<div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 						{workGallery.map((image) => (
 							<figure key={image.src}>
-								<div className="relative aspect-[4/5] overflow-hidden rounded-2xl bg-neutral-900">
+								<div className="relative aspect-[4/5] overflow-hidden rounded-lg bg-panel-elevated">
 									<Image
 										alt={image.alt}
 										className="object-cover"
@@ -373,7 +316,7 @@ export default function HomePage() {
 										src={image.src}
 									/>
 								</div>
-								<figcaption className="mt-3 text-sm font-bold text-neutral-300">
+								<figcaption className="mt-3 text-sm font-bold text-white/65">
 									{image.caption}
 								</figcaption>
 							</figure>
@@ -382,15 +325,13 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="bg-neutral-50 py-20">
-				<div className="mx-auto max-w-7xl px-4 md:px-8">
+			<section className="section-y bg-secondary/60">
+				<div className="container-shell">
 					<div className="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
 						<div className="max-w-2xl">
 							<Badge>What We Do</Badge>
-							<h2 className="mt-5 text-4xl font-black tracking-tight">
-								Plumbing &amp; Septic Services
-							</h2>
-							<p className="text-muted-foreground mt-4 text-lg">
+							<h2 className="type-title mt-5">Plumbing &amp; septic services</h2>
+							<p className="type-lead mt-4">
 								From routine maintenance to complex installations, our licensed
 								team handles it cleanly, honestly, and on time.
 							</p>
@@ -422,10 +363,10 @@ export default function HomePage() {
 									<CardDescription>{group.description}</CardDescription>
 								</CardHeader>
 								<CardContent>
-									<ul className="space-y-2 text-sm text-neutral-600">
+									<ul className="space-y-2 text-sm text-muted-foreground">
 										{group.items.map((item) => (
 											<li className="flex items-center gap-2" key={item}>
-												<Check className="text-primary size-4" />
+												<Check className="size-4 text-primary" />
 												{item}
 											</li>
 										))}
@@ -437,9 +378,9 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-y bg-white py-12">
-				<div className="mx-auto max-w-7xl px-4 md:px-8">
-					<p className="text-muted-foreground text-center text-xs font-black tracking-[0.18em] uppercase">
+			<section className="border-y border-border bg-card py-12">
+				<div className="container-shell">
+					<p className="text-center text-xs font-extrabold tracking-[0.16em] text-muted-foreground uppercase">
 						Experienced with leading plumbing equipment brands
 					</p>
 					<div className="mt-8 grid grid-cols-2 items-center gap-8 sm:grid-cols-3 lg:grid-cols-5">
@@ -462,14 +403,14 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="py-20">
-				<div className="mx-auto grid max-w-7xl gap-12 px-4 md:px-8 lg:grid-cols-[0.9fr_1.1fr]">
+			<section className="section-y">
+				<div className="container-shell grid gap-12 lg:grid-cols-[0.9fr_1.1fr]">
 					<div>
 						<Badge>Why Choose Wade&apos;s</Badge>
-						<h2 className="mt-5 text-4xl font-black tracking-tight">
+						<h2 className="type-title mt-5">
 							Real people. Honest recommendations.
 						</h2>
-						<p className="text-muted-foreground mt-5 text-lg leading-relaxed">
+						<p className="type-lead mt-5">
 							We are not corporate plumbers trying to hit an upsell quota. We
 							explain the issue, show you practical options, and do quality work
 							at a fair price.
@@ -484,19 +425,19 @@ export default function HomePage() {
 									"Repairs and systems designed to last.",
 								],
 							].map(([title, text]) => (
-								<div className="rounded-xl border p-5" key={title}>
-									<Wrench className="text-primary size-5" />
-									<h3 className="mt-3 font-black">{title}</h3>
-									<p className="text-muted-foreground mt-1 text-sm">{text}</p>
+								<div className="surface-panel p-5" key={title}>
+									<Wrench className="size-5 text-primary" />
+									<h3 className="mt-3 font-extrabold tracking-[-0.02em]">
+										{title}
+									</h3>
+									<p className="mt-1 text-sm text-muted-foreground">{text}</p>
 								</div>
 							))}
 						</div>
 					</div>
 
-					<div className="rounded-3xl bg-[#111] p-7 text-white sm:p-10">
-						<p className="text-primary-bright text-sm font-black tracking-wider uppercase">
-							Real People, Real Results
-						</p>
+					<div className="surface-dark rounded-lg p-7 sm:p-10">
+						<p className="type-eyebrow">Real People, Real Results</p>
 						<div className="mt-7 space-y-6">
 							{[
 								[
@@ -512,9 +453,13 @@ export default function HomePage() {
 									className="border-b border-white/10 pb-6 last:border-0 last:pb-0"
 									key={person}
 								>
-									<div className="text-amber-400">★★★★★</div>
-									<p className="mt-3 text-lg leading-relaxed">“{quote}”</p>
-									<footer className="mt-3 text-sm font-bold text-neutral-400">
+									<div className="text-primary-bright" aria-label="5 stars">
+										★★★★★
+									</div>
+									<p className="mt-3 text-lg leading-relaxed text-white">
+										“{quote}”
+									</p>
+									<footer className="mt-3 text-sm font-bold text-white/50">
 										{person}
 									</footer>
 								</blockquote>
@@ -534,14 +479,14 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-y bg-neutral-50 py-20">
-				<div className="mx-auto grid max-w-7xl gap-12 px-4 md:px-8 lg:grid-cols-[0.8fr_1.2fr]">
+			<section className="section-y border-y border-border bg-secondary/60">
+				<div className="container-shell grid gap-12 lg:grid-cols-[0.8fr_1.2fr]">
 					<div>
 						<Badge>Frequently Asked Questions</Badge>
-						<h2 className="mt-5 text-4xl font-black tracking-tight">
+						<h2 className="type-title mt-5">
 							Straight answers to common questions.
 						</h2>
-						<p className="text-muted-foreground mt-4">
+						<p className="type-lead mt-4">
 							Do not see your question? Call and talk to someone who understands
 							the work.
 						</p>

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -115,12 +115,12 @@ export default async function ServiceCategoryPage({
 			/>
 			<Suspense
 				fallback={
-					<section className="mx-auto max-w-7xl px-4 py-16 md:px-8">
+					<section className="container-shell section-y">
 						Loading services…
 					</section>
 				}
 			>
-				<section className="mx-auto grid max-w-7xl gap-5 px-4 py-16 md:grid-cols-2 md:px-8 lg:grid-cols-3 lg:py-20">
+				<section className="container-shell section-y grid gap-5 md:grid-cols-2 lg:grid-cols-3">
 					{services.map((service) => (
 						<ServiceCard key={service.slug} service={service} />
 					))}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -32,7 +32,7 @@ async function ServiceDirectory() {
 
 				return (
 					<section key={category}>
-						<div className="mb-7 flex items-end justify-between gap-5 border-b border-border pb-5">
+						<div className="border-border mb-7 flex items-end justify-between gap-5 border-b pb-5">
 							<div>
 								<p className="type-eyebrow">
 									{categoryServices.length} services
@@ -67,9 +67,7 @@ export default function ServicesPage() {
 
 			<Suspense
 				fallback={
-					<div className="container-shell section-y">
-						Loading services…
-					</div>
+					<div className="container-shell section-y">Loading services…</div>
 				}
 			>
 				<ServiceDirectory />

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -22,7 +22,7 @@ async function ServiceDirectory() {
 	const categories = ["Septic", "Plumbing", "Commercial"] as const
 
 	return (
-		<div className="mx-auto max-w-7xl space-y-16 px-4 py-16 md:px-8 lg:py-20">
+		<div className="container-shell section-y space-y-16">
 			{categories.map((category) => {
 				const categoryServices = services.filter(
 					(service) => service.category === category,
@@ -32,12 +32,12 @@ async function ServiceDirectory() {
 
 				return (
 					<section key={category}>
-						<div className="mb-7 flex items-end justify-between gap-5 border-b pb-5">
+						<div className="mb-7 flex items-end justify-between gap-5 border-b border-border pb-5">
 							<div>
-								<p className="text-primary text-sm font-black tracking-wider uppercase">
+								<p className="type-eyebrow">
 									{categoryServices.length} services
 								</p>
-								<h2 className="mt-1 text-3xl font-black tracking-tight">
+								<h2 className="mt-2 text-3xl font-extrabold tracking-[-0.03em]">
 									{category}
 								</h2>
 							</div>
@@ -67,7 +67,7 @@ export default function ServicesPage() {
 
 			<Suspense
 				fallback={
-					<div className="mx-auto max-w-7xl px-4 py-16 md:px-8">
+					<div className="container-shell section-y">
 						Loading services…
 					</div>
 				}

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -41,7 +41,7 @@ export function ArticleArchive({
 						key={post.slug}
 					>
 						<Link
-							className="relative block aspect-[16/9] overflow-hidden bg-muted"
+							className="bg-muted relative block aspect-[16/9] overflow-hidden"
 							href={`/${post.slug}` as Route}
 							tabIndex={-1}
 						>
@@ -60,20 +60,20 @@ export function ArticleArchive({
 							<Badge className="w-fit" tone="muted">
 								{post.category ?? "Expert Tips"}
 							</Badge>
-							<CardTitle className="mt-3 group-hover:text-primary">
+							<CardTitle className="group-hover:text-primary mt-3">
 								<Link href={`/${post.slug}` as Route}>{post.title}</Link>
 							</CardTitle>
 							<CardDescription>{post.description}</CardDescription>
 						</CardHeader>
 						<CardContent className="mt-auto">
 							{post.date ? (
-								<p className="mb-4 flex items-center gap-2 text-xs font-bold text-muted-foreground">
-									<CalendarDays className="size-4 text-primary" />
+								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
+									<CalendarDays className="text-primary size-4" />
 									{post.date}
 								</p>
 							) : null}
 							<Link
-								className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
+								className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
 								href={`/${post.slug}` as Route}
 							>
 								Read guide

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -34,14 +34,14 @@ export function ArticleArchive({
 				parent={{ href: "/expert-tips", label: "Expert Tips" }}
 				title={title}
 			/>
-			<section className="mx-auto grid max-w-7xl gap-5 px-4 py-16 md:grid-cols-2 md:px-8 lg:grid-cols-3 lg:py-20">
+			<section className="container-shell section-y grid gap-5 md:grid-cols-2 lg:grid-cols-3">
 				{posts.map((post) => (
 					<Card
 						className="group flex h-full flex-col overflow-hidden"
 						key={post.slug}
 					>
 						<Link
-							className="relative block aspect-[16/9] overflow-hidden bg-neutral-100"
+							className="relative block aspect-[16/9] overflow-hidden bg-muted"
 							href={`/${post.slug}` as Route}
 							tabIndex={-1}
 						>
@@ -57,21 +57,23 @@ export function ArticleArchive({
 							/>
 						</Link>
 						<CardHeader>
-							<Badge className="w-fit">{post.category ?? "Expert Tips"}</Badge>
-							<CardTitle className="group-hover:text-primary mt-3">
+							<Badge className="w-fit" tone="muted">
+								{post.category ?? "Expert Tips"}
+							</Badge>
+							<CardTitle className="mt-3 group-hover:text-primary">
 								<Link href={`/${post.slug}` as Route}>{post.title}</Link>
 							</CardTitle>
 							<CardDescription>{post.description}</CardDescription>
 						</CardHeader>
 						<CardContent className="mt-auto">
 							{post.date ? (
-								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
-									<CalendarDays className="text-primary size-4" />
+								<p className="mb-4 flex items-center gap-2 text-xs font-bold text-muted-foreground">
+									<CalendarDays className="size-4 text-primary" />
 									{post.date}
 								</p>
 							) : null}
 							<Link
-								className="text-primary inline-flex items-center gap-2 text-sm font-black"
+								className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
 								href={`/${post.slug}` as Route}
 							>
 								Read guide

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -35,14 +35,14 @@ export function ContactCta({
 					{!compact ? (
 						<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-white/70">
 							<span className="inline-flex items-center gap-2">
-								<Clock className="size-4 text-primary-bright" />
+								<Clock className="text-primary-bright size-4" />
 								{siteConfig.hours}
 							</span>
 							<a
 								className="inline-flex items-center gap-2 transition-colors hover:text-white"
 								href={`mailto:${siteConfig.email}`}
 							>
-								<Mail className="size-4 text-primary-bright" />
+								<Mail className="text-primary-bright size-4" />
 								{siteConfig.email}
 							</a>
 						</div>

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -17,39 +17,36 @@ export function ContactCta({
 	return (
 		<section
 			className={cn(
-				"relative overflow-hidden bg-[#111] text-white",
-				compact ? "rounded-2xl p-7 sm:p-9" : "py-16",
+				"surface-dark relative overflow-hidden",
+				compact ? "rounded-lg p-7 sm:p-9" : "section-y",
 			)}
 		>
-			<div className="bg-primary/15 pointer-events-none absolute -top-24 -right-24 size-72 rounded-full blur-3xl" />
 			<div
 				className={cn(
 					"relative",
 					!compact &&
-						"mx-auto flex max-w-7xl flex-col gap-8 px-4 md:flex-row md:items-center md:justify-between md:px-8",
+						"container-shell flex flex-col gap-8 md:flex-row md:items-center md:justify-between",
 				)}
 			>
 				<div className="max-w-2xl">
-					<p className="text-primary-bright mb-2 text-xs font-black tracking-[0.18em] uppercase">
-						Wade&apos;s Plumbing &amp; Septic
-					</p>
-					<h2 className="text-3xl font-black tracking-tight sm:text-4xl">
-						{title}
-					</h2>
-					<p className="mt-3 leading-relaxed text-neutral-200">{description}</p>
-					<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-neutral-300">
-						<span className="inline-flex items-center gap-2">
-							<Clock className="text-primary-bright size-4" />
-							{siteConfig.hours}
-						</span>
-						<a
-							className="inline-flex items-center gap-2 hover:text-white"
-							href={`mailto:${siteConfig.email}`}
-						>
-							<Mail className="text-primary-bright size-4" />
-							{siteConfig.email}
-						</a>
-					</div>
+					<p className="type-eyebrow mb-3">Wade&apos;s Plumbing &amp; Septic</p>
+					<h2 className="type-title text-white">{title}</h2>
+					<p className="type-lead mt-3">{description}</p>
+					{!compact ? (
+						<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-white/70">
+							<span className="inline-flex items-center gap-2">
+								<Clock className="size-4 text-primary-bright" />
+								{siteConfig.hours}
+							</span>
+							<a
+								className="inline-flex items-center gap-2 transition-colors hover:text-white"
+								href={`mailto:${siteConfig.email}`}
+							>
+								<Mail className="size-4 text-primary-bright" />
+								{siteConfig.email}
+							</a>
+						</div>
+					) : null}
 				</div>
 
 				<div

--- a/components/content-gallery.tsx
+++ b/components/content-gallery.tsx
@@ -10,7 +10,7 @@ export function ContentGallery({ images }: { images: ContentImage[] }) {
 					className={index === 0 && images.length % 2 ? "sm:col-span-2" : ""}
 					key={image.src}
 				>
-					<div className="relative aspect-[4/3] overflow-hidden rounded-2xl bg-neutral-100">
+					<div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
 						<Image
 							alt={image.alt}
 							className="object-cover"

--- a/components/content-gallery.tsx
+++ b/components/content-gallery.tsx
@@ -10,7 +10,7 @@ export function ContentGallery({ images }: { images: ContentImage[] }) {
 					className={index === 0 && images.length % 2 ? "sm:col-span-2" : ""}
 					key={image.src}
 				>
-					<div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
+					<div className="bg-muted relative aspect-[4/3] overflow-hidden rounded-lg">
 						<Image
 							alt={image.alt}
 							className="object-cover"

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -23,50 +23,44 @@ export function ContentHero({
 	parent?: { href: Route; label: string }
 }) {
 	return (
-		<section className="relative overflow-hidden bg-[#111] text-white">
+		<section className="surface-dark relative overflow-hidden">
 			{image ? (
 				<>
 					<Image
 						alt={imageAlt ?? ""}
-						className="object-cover opacity-25"
+						className="object-cover opacity-30"
 						fill
 						priority
 						quality={70}
 						sizes="100vw"
 						src={image}
 					/>
-					<div className="absolute inset-0 bg-linear-to-r from-[#111] via-[#111]/90 to-[#111]/50" />
+					<div className="absolute inset-0 bg-linear-to-r from-ink via-ink/90 to-ink/55" />
 				</>
 			) : null}
-			<div className="bg-primary/12 pointer-events-none absolute -top-48 -right-40 size-[36rem] rounded-full blur-3xl" />
-			<div className="relative mx-auto max-w-7xl px-4 py-16 md:px-8 lg:py-20">
+			<div className="container-shell relative py-16 lg:py-20">
 				<nav
-					className="mb-7 flex flex-wrap items-center gap-1 text-xs font-bold text-neutral-400"
+					className="mb-7 flex flex-wrap items-center gap-1 text-xs font-bold text-white/50"
 					aria-label="Breadcrumb"
 				>
-					<Link className="hover:text-white" href="/">
+					<Link className="transition-colors hover:text-white" href="/">
 						Home
 					</Link>
 					{parent ? (
 						<>
 							<ChevronRight className="size-3" />
-							<Link className="hover:text-white" href={parent.href}>
+							<Link
+								className="transition-colors hover:text-white"
+								href={parent.href}
+							>
 								{parent.label}
 							</Link>
 						</>
 					) : null}
 				</nav>
-				{eyebrow ? (
-					<Badge className="border-primary-bright/40 bg-primary-bright/15 text-primary-bright">
-						{eyebrow}
-					</Badge>
-				) : null}
-				<h1 className="mt-5 max-w-4xl text-4xl leading-tight font-black tracking-[-0.04em] text-balance sm:text-5xl lg:text-6xl">
-					{title}
-				</h1>
-				<p className="mt-5 max-w-3xl text-lg leading-relaxed text-neutral-300">
-					{description}
-				</p>
+				{eyebrow ? <Badge tone="inverse">{eyebrow}</Badge> : null}
+				<h1 className="type-display mt-5 max-w-4xl text-white">{title}</h1>
+				<p className="type-lead mt-5 max-w-3xl">{description}</p>
 				<div className="mt-8 flex flex-col gap-3 sm:flex-row">
 					<a
 						className={buttonVariants({ size: "xl" })}

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -35,7 +35,7 @@ export function ContentHero({
 						sizes="100vw"
 						src={image}
 					/>
-					<div className="absolute inset-0 bg-linear-to-r from-ink via-ink/90 to-ink/55" />
+					<div className="from-ink via-ink/90 to-ink/55 absolute inset-0 bg-linear-to-r" />
 				</>
 			) : null}
 			<div className="container-shell relative py-16 lg:py-20">

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -42,7 +42,7 @@ export function ContentPage({
 				parent={parent}
 				title={document.title}
 			/>
-			<article className="mx-auto grid max-w-7xl gap-10 px-4 py-14 md:px-8 lg:grid-cols-[minmax(0,1fr)_20rem] lg:py-20">
+			<article className="container-shell section-y grid gap-10 lg:grid-cols-[minmax(0,1fr)_20rem]">
 				<div>
 					{isPost && document.date ? (
 						<p className="text-muted-foreground mb-8 text-sm font-bold">

--- a/components/service-card.tsx
+++ b/components/service-card.tsx
@@ -19,9 +19,9 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 	const image = getServiceImage(service.category, service.image)
 
 	return (
-		<Card className="group hover:border-primary/40 flex h-full flex-col overflow-hidden transition-all duration-200 hover:-translate-y-0.5 hover:shadow-lg">
+		<Card className="group flex h-full flex-col overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5 hover:border-primary/35">
 			<Link
-				className="relative block aspect-[16/9] overflow-hidden bg-neutral-100"
+				className="relative block aspect-[16/9] overflow-hidden bg-muted"
 				href={href}
 				prefetch
 				tabIndex={-1}
@@ -36,8 +36,10 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 				/>
 			</Link>
 			<CardHeader>
-				<Badge className="w-fit">{service.category}</Badge>
-				<CardTitle className="group-hover:text-primary mt-3 transition-colors">
+				<Badge className="w-fit" tone="muted">
+					{service.category}
+				</Badge>
+				<CardTitle className="mt-3 transition-colors group-hover:text-primary">
 					<Link href={href} prefetch>
 						{service.title}
 					</Link>
@@ -46,7 +48,7 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 			</CardHeader>
 			<CardContent className="mt-auto">
 				<Link
-					className="text-primary inline-flex items-center gap-2 text-sm font-black"
+					className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
 					href={href}
 					prefetch
 				>

--- a/components/service-card.tsx
+++ b/components/service-card.tsx
@@ -19,9 +19,9 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 	const image = getServiceImage(service.category, service.image)
 
 	return (
-		<Card className="group flex h-full flex-col overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5 hover:border-primary/35">
+		<Card className="group hover:border-primary/35 flex h-full flex-col overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5">
 			<Link
-				className="relative block aspect-[16/9] overflow-hidden bg-muted"
+				className="bg-muted relative block aspect-[16/9] overflow-hidden"
 				href={href}
 				prefetch
 				tabIndex={-1}
@@ -39,7 +39,7 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 				<Badge className="w-fit" tone="muted">
 					{service.category}
 				</Badge>
-				<CardTitle className="mt-3 transition-colors group-hover:text-primary">
+				<CardTitle className="group-hover:text-primary mt-3 transition-colors">
 					<Link href={href} prefetch>
 						{service.title}
 					</Link>
@@ -48,7 +48,7 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 			</CardHeader>
 			<CardContent className="mt-auto">
 				<Link
-					className="inline-flex items-center gap-2 text-sm font-extrabold text-primary"
+					className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
 					href={href}
 					prefetch
 				>

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -55,10 +55,10 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 							"Testing and cleanup before completion",
 						].map((item) => (
 							<div
-								className="flex items-center gap-3 rounded-lg border border-border bg-secondary/50 p-4 text-sm font-bold"
+								className="border-border bg-secondary/50 flex items-center gap-3 rounded-lg border p-4 text-sm font-bold"
 								key={item}
 							>
-								<span className="grid size-8 shrink-0 place-items-center rounded-md bg-accent text-accent-foreground">
+								<span className="bg-accent text-accent-foreground grid size-8 shrink-0 place-items-center rounded-md">
 									<Check className="size-4" />
 								</span>
 								{item}
@@ -82,7 +82,7 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 								<span>{siteConfig.licenses}</span>
 							</div>
 							<a
-								className="flex items-center gap-3 font-extrabold text-primary"
+								className="text-primary flex items-center gap-3 font-extrabold"
 								href={siteConfig.phoneHref}
 							>
 								<Phone className="size-5" />

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -43,7 +43,7 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 				title={service.title}
 			/>
 
-			<section className="mx-auto grid max-w-7xl gap-10 px-4 py-14 md:px-8 lg:grid-cols-[minmax(0,1fr)_21rem] lg:py-20">
+			<section className="container-shell section-y grid gap-10 lg:grid-cols-[minmax(0,1fr)_21rem]">
 				<article>
 					<MarkdownContent content={service.content} />
 
@@ -55,10 +55,10 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 							"Testing and cleanup before completion",
 						].map((item) => (
 							<div
-								className="flex items-center gap-3 rounded-xl border bg-neutral-50 p-4 text-sm font-bold"
+								className="flex items-center gap-3 rounded-lg border border-border bg-secondary/50 p-4 text-sm font-bold"
 								key={item}
 							>
-								<span className="bg-primary/10 text-primary grid size-8 shrink-0 place-items-center rounded-full">
+								<span className="grid size-8 shrink-0 place-items-center rounded-md bg-accent text-accent-foreground">
 									<Check className="size-4" />
 								</span>
 								{item}
@@ -82,7 +82,7 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 								<span>{siteConfig.licenses}</span>
 							</div>
 							<a
-								className="text-primary flex items-center gap-3 font-black"
+								className="flex items-center gap-3 font-extrabold text-primary"
 								href={siteConfig.phoneHref}
 							>
 								<Phone className="size-5" />

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -3,7 +3,9 @@ import Image from "next/image"
 import Link from "next/link"
 import { Phone } from "lucide-react"
 
+import { buttonVariants } from "@/components/ui/button"
 import { companyNavigation, resourceNavigation, siteConfig } from "@/lib/site"
+import { cn } from "@/lib/utils"
 
 const serviceLinks = [
 	{ href: "/service-offerings/drain-cleaning", label: "Drain Cleaning" },
@@ -23,17 +25,22 @@ const serviceLinks = [
 
 export function SiteFooter() {
 	return (
-		<footer className="bg-[#0b0b0b] text-white">
-			<div className="bg-primary border-b border-white/10">
-				<div className="mx-auto flex max-w-7xl flex-col items-center justify-between gap-4 px-4 py-6 text-center sm:flex-row sm:text-left md:px-8">
+		<footer className="bg-ink text-white">
+			<div className="border-b border-white/10 bg-primary">
+				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
 						<p className="text-sm font-bold text-white/80">
 							24/7 Emergency Service
 						</p>
-						<p className="text-2xl font-black">{siteConfig.phone}</p>
+						<p className="text-2xl font-extrabold tracking-[-0.03em]">
+							{siteConfig.phone}
+						</p>
 					</div>
 					<a
-						className="inline-flex h-12 items-center gap-2 rounded-lg bg-white px-6 font-black text-neutral-950 hover:bg-neutral-100"
+						className={cn(
+							buttonVariants({ variant: "secondary", size: "lg" }),
+							"gap-2 bg-white text-foreground hover:bg-white/90",
+						)}
 						href={siteConfig.phoneHref}
 					>
 						<Phone className="size-4" aria-hidden="true" />
@@ -42,58 +49,51 @@ export function SiteFooter() {
 				</div>
 			</div>
 
-			<div className="mx-auto max-w-7xl px-4 py-16 md:px-8">
+			<div className="container-shell py-16">
 				<div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
 					<div>
 						<Link
-							className="flex items-center gap-3 text-xl font-black"
+							className="flex items-center gap-3 text-lg font-extrabold tracking-[-0.03em]"
 							href="/"
 						>
-							<span className="grid size-14 place-items-center rounded-xl bg-white p-1.5">
+							<span className="grid size-12 place-items-center rounded-md bg-white p-1.5">
 								<Image
 									alt=""
-									height={48}
+									height={40}
 									src="/images/brand/wades-mark.webp"
-									width={48}
+									width={40}
 								/>
 							</span>
 							<span>Wade&apos;s Plumbing &amp; Septic</span>
 						</Link>
-						<p className="mt-4 text-sm leading-relaxed text-neutral-400">
+						<p className="mt-4 text-sm leading-relaxed text-white/60">
 							Family-owned plumbing and septic specialists. Honest
 							recommendations, clear pricing, and quality workmanship.
 						</p>
-						<p className="mt-4 text-xs font-semibold text-neutral-400">
+						<p className="mt-4 text-xs font-semibold text-white/45">
 							{siteConfig.licenses}
 						</p>
 						<div className="mt-5 flex gap-3">
-							<a
-								className="grid size-10 place-items-center rounded-lg border border-white/10 text-neutral-400 hover:text-white"
-								href={siteConfig.social.facebook}
-								aria-label="Facebook"
-							>
-								<span className="text-sm font-black" aria-hidden="true">
-									f
-								</span>
-							</a>
-							<a
-								className="grid size-10 place-items-center rounded-lg border border-white/10 text-neutral-400 hover:text-white"
-								href={siteConfig.social.linkedin}
-								aria-label="LinkedIn"
-							>
-								<span className="text-xs font-black" aria-hidden="true">
-									in
-								</span>
-							</a>
-							<a
-								className="grid size-10 place-items-center rounded-lg border border-white/10 text-neutral-400 hover:text-white"
-								href={siteConfig.social.instagram}
-								aria-label="Instagram"
-							>
-								<span className="text-sm font-black" aria-hidden="true">
-									i
-								</span>
-							</a>
+							{[
+								{ href: siteConfig.social.facebook, label: "Facebook", mark: "f" },
+								{ href: siteConfig.social.linkedin, label: "LinkedIn", mark: "in" },
+								{
+									href: siteConfig.social.instagram,
+									label: "Instagram",
+									mark: "i",
+								},
+							].map((item) => (
+								<a
+									className="grid size-10 place-items-center rounded-md border border-white/12 text-white/55 transition-colors hover:border-white/30 hover:text-white"
+									href={item.href}
+									aria-label={item.label}
+									key={item.label}
+								>
+									<span className="text-xs font-extrabold" aria-hidden="true">
+										{item.mark}
+									</span>
+								</a>
+							))}
 						</div>
 					</div>
 
@@ -102,16 +102,16 @@ export function SiteFooter() {
 					<FooterColumn title="Resources" links={resourceNavigation} />
 				</div>
 
-				<div className="mt-14 flex flex-col gap-4 border-t border-white/10 pt-7 text-xs text-neutral-400 sm:flex-row sm:items-center sm:justify-between">
+				<div className="mt-14 flex flex-col gap-4 border-t border-white/10 pt-7 text-xs text-white/45 sm:flex-row sm:items-center sm:justify-between">
 					<p>© 2026 Wade&apos;s Plumbing &amp; Septic. All rights reserved.</p>
 					<div className="flex gap-5">
-						<Link className="hover:text-white" href="/privacy-policy">
+						<Link className="transition-colors hover:text-white" href="/privacy-policy">
 							Privacy Policy
 						</Link>
-						<Link className="hover:text-white" href="/terms-of-service">
+						<Link className="transition-colors hover:text-white" href="/terms-of-service">
 							Terms
 						</Link>
-						<Link className="hover:text-white" href="/sitemap.xml">
+						<Link className="transition-colors hover:text-white" href="/sitemap.xml">
 							Sitemap
 						</Link>
 					</div>
@@ -130,12 +130,14 @@ function FooterColumn({
 }) {
 	return (
 		<div>
-			<h2 className="text-sm font-black tracking-wider uppercase">{title}</h2>
-			<ul className="mt-4 space-y-3 text-sm text-neutral-400">
+			<h2 className="text-xs font-extrabold tracking-[0.16em] uppercase">
+				{title}
+			</h2>
+			<ul className="mt-4 space-y-3 text-sm text-white/55">
 				{links.map((link) => (
 					<li key={link.href}>
 						<Link
-							className="hover:text-primary transition-colors"
+							className="transition-colors hover:text-primary-bright"
 							href={link.href as Route}
 						>
 							{link.label}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -26,7 +26,7 @@ const serviceLinks = [
 export function SiteFooter() {
 	return (
 		<footer className="bg-ink text-white">
-			<div className="border-b border-white/10 bg-primary">
+			<div className="bg-primary border-b border-white/10">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
 						<p className="text-sm font-bold text-white/80">
@@ -39,7 +39,7 @@ export function SiteFooter() {
 					<a
 						className={cn(
 							buttonVariants({ variant: "secondary", size: "lg" }),
-							"gap-2 bg-white text-foreground hover:bg-white/90",
+							"text-foreground gap-2 bg-white hover:bg-white/90",
 						)}
 						href={siteConfig.phoneHref}
 					>
@@ -75,8 +75,16 @@ export function SiteFooter() {
 						</p>
 						<div className="mt-5 flex gap-3">
 							{[
-								{ href: siteConfig.social.facebook, label: "Facebook", mark: "f" },
-								{ href: siteConfig.social.linkedin, label: "LinkedIn", mark: "in" },
+								{
+									href: siteConfig.social.facebook,
+									label: "Facebook",
+									mark: "f",
+								},
+								{
+									href: siteConfig.social.linkedin,
+									label: "LinkedIn",
+									mark: "in",
+								},
 								{
 									href: siteConfig.social.instagram,
 									label: "Instagram",
@@ -105,13 +113,22 @@ export function SiteFooter() {
 				<div className="mt-14 flex flex-col gap-4 border-t border-white/10 pt-7 text-xs text-white/45 sm:flex-row sm:items-center sm:justify-between">
 					<p>© 2026 Wade&apos;s Plumbing &amp; Septic. All rights reserved.</p>
 					<div className="flex gap-5">
-						<Link className="transition-colors hover:text-white" href="/privacy-policy">
+						<Link
+							className="transition-colors hover:text-white"
+							href="/privacy-policy"
+						>
 							Privacy Policy
 						</Link>
-						<Link className="transition-colors hover:text-white" href="/terms-of-service">
+						<Link
+							className="transition-colors hover:text-white"
+							href="/terms-of-service"
+						>
 							Terms
 						</Link>
-						<Link className="transition-colors hover:text-white" href="/sitemap.xml">
+						<Link
+							className="transition-colors hover:text-white"
+							href="/sitemap.xml"
+						>
 							Sitemap
 						</Link>
 					</div>
@@ -137,7 +154,7 @@ function FooterColumn({
 				{links.map((link) => (
 					<li key={link.href}>
 						<Link
-							className="transition-colors hover:text-primary-bright"
+							className="hover:text-primary-bright transition-colors"
 							href={link.href as Route}
 						>
 							{link.label}

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils"
 
 export function SiteHeader() {
 	return (
-		<header className="sticky top-0 z-50 border-b border-white/10 bg-ink/95 text-white backdrop-blur-md">
+		<header className="bg-ink/95 sticky top-0 z-50 border-b border-white/10 text-white backdrop-blur-md">
 			<div className="hidden border-b border-white/10 bg-black/40 sm:block">
 				<div className="container-shell flex items-center justify-between py-2 text-xs text-white/65">
 					<span>{siteConfig.hours}</span>
@@ -40,7 +40,7 @@ export function SiteHeader() {
 						<span className="block text-base font-extrabold tracking-[-0.03em] sm:text-lg">
 							Wade&apos;s Plumbing
 						</span>
-						<span className="mt-1 block text-[0.68rem] font-extrabold tracking-[0.18em] text-primary-bright uppercase">
+						<span className="text-primary-bright mt-1 block text-[0.68rem] font-extrabold tracking-[0.18em] uppercase">
 							&amp; Septic
 						</span>
 					</span>
@@ -52,7 +52,7 @@ export function SiteHeader() {
 				>
 					{primaryNavigation.map((item) => (
 						<Link
-							className="text-sm font-bold text-white/80 transition-colors hover:text-primary-bright"
+							className="hover:text-primary-bright text-sm font-bold text-white/80 transition-colors"
 							href={item.href}
 							key={item.href}
 							prefetch
@@ -78,12 +78,12 @@ export function SiteHeader() {
 						<span className="sr-only">Open main menu</span>
 					</summary>
 					<nav
-						className="absolute top-14 right-0 w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-white/10 bg-panel-elevated p-2"
+						className="bg-panel-elevated absolute top-14 right-0 w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-white/10 p-2"
 						aria-label="Mobile navigation"
 					>
 						{primaryNavigation.map((item) => (
 							<Link
-								className="block rounded-md px-4 py-3 font-bold transition-colors hover:bg-white/5 hover:text-primary-bright"
+								className="hover:text-primary-bright block rounded-md px-4 py-3 font-bold transition-colors hover:bg-white/5"
 								href={item.href}
 								key={item.href}
 								prefetch

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -8,12 +8,12 @@ import { cn } from "@/lib/utils"
 
 export function SiteHeader() {
 	return (
-		<header className="sticky top-0 z-50 border-b border-white/10 bg-[#111]/95 text-white shadow-lg backdrop-blur">
-			<div className="hidden border-b border-white/10 bg-black/50 sm:block">
-				<div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 text-xs text-neutral-300 md:px-8">
+		<header className="sticky top-0 z-50 border-b border-white/10 bg-ink/95 text-white backdrop-blur-md">
+			<div className="hidden border-b border-white/10 bg-black/40 sm:block">
+				<div className="container-shell flex items-center justify-between py-2 text-xs text-white/65">
 					<span>{siteConfig.hours}</span>
 					<Link
-						className="font-semibold hover:text-white"
+						className="font-semibold transition-colors hover:text-white"
 						href="/service-areas"
 					>
 						{siteConfig.serviceArea}
@@ -21,38 +21,38 @@ export function SiteHeader() {
 				</div>
 			</div>
 
-			<div className="mx-auto flex h-18 max-w-7xl items-center justify-between px-4 md:px-8">
+			<div className="container-shell flex h-18 items-center justify-between">
 				<Link
 					className="flex items-center gap-3"
 					href="/"
 					aria-label="Wade's Plumbing & Septic home"
 				>
-					<span className="grid size-12 place-items-center rounded-xl bg-white p-1 shadow-sm">
+					<span className="grid size-11 place-items-center rounded-md bg-white p-1">
 						<Image
 							alt=""
-							height={44}
+							height={40}
 							priority
 							src="/images/brand/wades-mark.webp"
-							width={44}
+							width={40}
 						/>
 					</span>
-					<span className="leading-tight">
-						<span className="block text-base font-black sm:text-lg">
+					<span className="leading-none">
+						<span className="block text-base font-extrabold tracking-[-0.03em] sm:text-lg">
 							Wade&apos;s Plumbing
 						</span>
-						<span className="text-primary-bright block text-xs font-bold tracking-[0.18em] uppercase">
+						<span className="mt-1 block text-[0.68rem] font-extrabold tracking-[0.18em] text-primary-bright uppercase">
 							&amp; Septic
 						</span>
 					</span>
 				</Link>
 
 				<nav
-					className="hidden items-center gap-6 lg:flex"
+					className="hidden items-center gap-7 lg:flex"
 					aria-label="Primary navigation"
 				>
 					{primaryNavigation.map((item) => (
 						<Link
-							className="hover:text-primary-bright text-sm font-bold text-neutral-200 transition-colors"
+							className="text-sm font-bold text-white/80 transition-colors hover:text-primary-bright"
 							href={item.href}
 							key={item.href}
 							prefetch
@@ -73,17 +73,17 @@ export function SiteHeader() {
 				</div>
 
 				<details className="group relative sm:hidden">
-					<summary className="grid size-11 cursor-pointer list-none place-items-center rounded-lg border border-white/15 bg-white/5 [&::-webkit-details-marker]:hidden">
+					<summary className="grid size-11 cursor-pointer list-none place-items-center rounded-md border border-white/15 bg-white/5 [&::-webkit-details-marker]:hidden">
 						<Menu aria-hidden="true" className="size-5" />
 						<span className="sr-only">Open main menu</span>
 					</summary>
 					<nav
-						className="absolute top-14 right-0 w-[min(20rem,calc(100vw-2rem))] rounded-2xl border border-white/10 bg-[#171717] p-3 shadow-2xl"
+						className="absolute top-14 right-0 w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-white/10 bg-panel-elevated p-2"
 						aria-label="Mobile navigation"
 					>
 						{primaryNavigation.map((item) => (
 							<Link
-								className="hover:text-primary-bright block rounded-lg px-4 py-3 font-bold hover:bg-white/5"
+								className="block rounded-md px-4 py-3 font-bold transition-colors hover:bg-white/5 hover:text-primary-bright"
 								href={item.href}
 								key={item.href}
 								prefetch

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ export function AccordionTrigger({
 		<AccordionPrimitive.Header className="flex">
 			<AccordionPrimitive.Trigger
 				className={cn(
-					"hover:text-primary flex flex-1 items-center justify-between py-5 text-left font-bold transition-colors [&[data-state=open]>svg]:rotate-180",
+					"flex flex-1 items-center justify-between gap-4 py-5 text-left text-base font-extrabold tracking-[-0.02em] transition-colors hover:text-primary [&[data-state=open]>svg]:rotate-180",
 					className,
 				)}
 				{...props}

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ export function AccordionTrigger({
 		<AccordionPrimitive.Header className="flex">
 			<AccordionPrimitive.Trigger
 				className={cn(
-					"flex flex-1 items-center justify-between gap-4 py-5 text-left text-base font-extrabold tracking-[-0.02em] transition-colors hover:text-primary [&[data-state=open]>svg]:rotate-180",
+					"hover:text-primary flex flex-1 items-center justify-between gap-4 py-5 text-left text-base font-extrabold tracking-[-0.02em] transition-colors [&[data-state=open]>svg]:rotate-180",
 					className,
 				)}
 				{...props}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -26,7 +26,5 @@ export function Badge({
 	tone,
 	...props
 }: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
-	return (
-		<span className={cn(badgeVariants({ tone }), className)} {...props} />
-	)
+	return <span className={cn(badgeVariants({ tone }), className)} {...props} />
 }

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,15 +1,32 @@
 import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-export function Badge({ className, ...props }: React.ComponentProps<"span">) {
+export const badgeVariants = cva(
+	"inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-[0.7rem] font-extrabold tracking-[0.14em] uppercase",
+	{
+		variants: {
+			tone: {
+				default: "border-primary/25 bg-accent text-accent-foreground",
+				bright:
+					"border-primary-bright/35 bg-primary-bright/12 text-primary-bright",
+				muted: "border-border bg-muted text-muted-foreground",
+				inverse: "border-white/20 bg-white/8 text-white",
+			},
+		},
+		defaultVariants: {
+			tone: "default",
+		},
+	},
+)
+
+export function Badge({
+	className,
+	tone,
+	...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
 	return (
-		<span
-			className={cn(
-				"border-primary/30 bg-primary/10 text-primary inline-flex items-center rounded-full border px-3 py-1 text-xs font-bold tracking-wide",
-				className,
-			)}
-			{...props}
-		/>
+		<span className={cn(badgeVariants({ tone }), className)} {...props} />
 	)
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -4,27 +4,27 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 export const buttonVariants = cva(
-	"inline-flex shrink-0 items-center justify-center gap-2 rounded-lg text-sm font-bold whitespace-nowrap transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+	"inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-bold whitespace-nowrap transition-[color,background-color,border-color,transform] duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:translate-y-px",
 	{
 		variants: {
 			variant: {
 				default:
-					"bg-primary text-primary-foreground shadow-sm hover:bg-primary/90",
+					"bg-primary text-primary-foreground hover:bg-[color-mix(in_srgb,var(--primary)_88%,black)]",
 				secondary:
-					"bg-secondary text-secondary-foreground hover:bg-secondary/80",
+					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_srgb,var(--secondary)_85%,var(--ink))]",
 				outline:
-					"border border-border bg-background hover:bg-accent hover:text-accent-foreground",
-				ghost: "hover:bg-accent hover:text-accent-foreground",
+					"border border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
+				ghost: "text-foreground hover:bg-muted",
 				link: "text-primary underline-offset-4 hover:underline",
 				inverse:
-					"border border-white/20 bg-white/5 text-white hover:bg-white/10",
+					"border border-white/25 bg-white/8 text-white hover:border-white/40 hover:bg-white/14",
 			},
 			size: {
-				default: "h-10 px-4 py-2",
-				sm: "h-9 rounded-md px-3",
+				default: "h-11 px-4 py-2",
+				sm: "h-9 rounded-md px-3 text-xs",
 				lg: "h-12 px-6 text-base",
-				xl: "h-14 px-7 text-lg",
-				icon: "size-10",
+				xl: "h-14 px-7 text-base tracking-[-0.01em]",
+				icon: "size-11",
 			},
 		},
 		defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -6,7 +6,7 @@ export function Card({ className, ...props }: React.ComponentProps<"div">) {
 	return (
 		<div
 			className={cn(
-				"border-border bg-card text-card-foreground rounded-2xl border shadow-sm",
+				"border-border bg-card text-card-foreground rounded-lg border shadow-[var(--shadow-edge)]",
 				className,
 			)}
 			{...props}
@@ -18,13 +18,16 @@ export function CardHeader({
 	className,
 	...props
 }: React.ComponentProps<"div">) {
-	return <div className={cn("p-6 pb-3", className)} {...props} />
+	return <div className={cn("p-5 pb-2", className)} {...props} />
 }
 
 export function CardTitle({ className, ...props }: React.ComponentProps<"h3">) {
 	return (
 		<h3
-			className={cn("text-xl font-extrabold tracking-tight", className)}
+			className={cn(
+				"text-lg font-extrabold tracking-[-0.02em] text-balance",
+				className,
+			)}
 			{...props}
 		/>
 	)
@@ -36,7 +39,10 @@ export function CardDescription({
 }: React.ComponentProps<"p">) {
 	return (
 		<p
-			className={cn("text-muted-foreground text-sm leading-relaxed", className)}
+			className={cn(
+				"text-muted-foreground mt-2 text-sm leading-relaxed",
+				className,
+			)}
 			{...props}
 		/>
 	)
@@ -46,5 +52,5 @@ export function CardContent({
 	className,
 	...props
 }: React.ComponentProps<"div">) {
-	return <div className={cn("p-6 pt-3", className)} {...props} />
+	return <div className={cn("p-5 pt-2", className)} {...props} />
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Unifies Wade's marketing UI around a definitive charcoal + copper system: shared tokens, layout/type utilities, sharper primitives, and aligned shell/content surfaces.

## Changes
- **Tokens & utilities** in `globals.css`: ink/panel/primary-bright palette, `container-shell`, `section-y`, `surface-dark*`, `type-*`, motion classes
- **Primitives**: button, badge (tone variants), card, accordion
- **Shell**: header, footer, content hero, contact CTA
- **Surfaces**: homepage (full-bleed brand-first hero), services, expert tips, cards, galleries, not-found

## Design direction
Charcoal + copper, cool stone neutrals, sharper radius, fewer pills/glows/shadow stacks. Dark accents use `primary-bright` for contrast; solid CTAs keep deeper `--primary`.

## Verification
`npm run check` passed (lint, typecheck, format, production build — 294 routes).

## Base
Stacked on `cursor/next16-preview-content-migration-0ab5` so this PR stays design-only relative to the Next 16 / content migration work.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

