### PR TITLE
Polish dark UI: drop white hairline borders + tighten mobile heroes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -225,7 +225,7 @@ summary {
 
 .surface-dark .type-lead,
 .surface-dark-soft .type-lead {
-	color: #d4d4d0;
+	color: #e4e5e7;
 }
 
 /* Dark-surface text floors for WCAG AA on ink/panel backgrounds */

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -138,7 +138,7 @@ const faqs = [
 export default function HomePage() {
 	return (
 		<main id="main-content">
-			<section className="surface-dark relative min-h-[min(92vh,52rem)] overflow-hidden">
+			<section className="surface-dark relative min-h-[min(78vh,44rem)] overflow-hidden sm:min-h-[min(92vh,52rem)]">
 				<Image
 					alt="Three-tank engineered septic system installed on a hillside property in Santa Cruz County"
 					className="object-cover object-center"
@@ -149,36 +149,43 @@ export default function HomePage() {
 					sizes="100vw"
 					src="/images/work/engineered-septic-hero.webp"
 				/>
-				<div className="from-ink via-ink/88 to-ink/45 absolute inset-0 bg-linear-to-r" />
-				<div className="from-ink/80 to-ink/35 absolute inset-0 bg-linear-to-t via-transparent" />
+				<div className="bg-ink/55 sm:bg-ink/40 absolute inset-0" />
+				<div className="from-ink via-ink/90 to-ink/55 absolute inset-0 bg-linear-to-r" />
+				<div className="from-ink via-ink/70 to-ink/25 absolute inset-0 bg-linear-to-t" />
 
-				<div className="container-shell relative flex min-h-[min(92vh,52rem)] flex-col justify-end pt-28 pb-16 lg:justify-center lg:pt-20 lg:pb-24">
+				<div className="container-shell relative flex min-h-[min(78vh,44rem)] flex-col justify-end pt-24 pb-12 sm:min-h-[min(92vh,52rem)] sm:pt-28 sm:pb-16 lg:justify-center lg:pt-20 lg:pb-24">
 					<div className="max-w-3xl">
 						<p className="type-eyebrow motion-fade text-primary-bright">
 							Wade&apos;s Plumbing &amp; Septic
 						</p>
-						<h1 className="type-display motion-rise mt-5 text-white">
+						<h1 className="type-display motion-rise mt-4 text-white sm:mt-5">
 							Honest plumbing
 							<br />
 							<span className="text-primary-bright">&amp; septic</span>
 						</h1>
-						<p className="type-lead motion-rise motion-delay-1 mt-6 max-w-xl">
+						<p className="motion-rise motion-delay-1 mt-5 max-w-xl text-base leading-relaxed text-[#ececea] sm:mt-6 sm:text-lg">
 							No sales pressure. No upselling. Clear pricing before work begins
 							from local licensed professionals.
 						</p>
-						<div className="motion-rise motion-delay-2 mt-8 flex flex-col gap-3 sm:flex-row">
+						<div className="motion-rise motion-delay-2 mt-7 flex w-full max-w-md flex-col gap-3 sm:mt-8 sm:max-w-none sm:flex-row">
 							<a
-								className={cn(buttonVariants({ size: "xl" }), "gap-2.5")}
+								className={cn(
+									buttonVariants({ size: "xl" }),
+									"w-full gap-2.5 sm:w-auto",
+								)}
 								href={siteConfig.phoneHref}
 							>
 								<Phone className="size-5" />
 								Call {siteConfig.phone}
 							</a>
 							<Link
-								className={buttonVariants({
-									variant: "inverse",
-									size: "xl",
-								})}
+								className={cn(
+									buttonVariants({
+										variant: "inverse",
+										size: "xl",
+									}),
+									"w-full sm:w-auto",
+								)}
 								href="/services"
 								prefetch
 							>
@@ -190,15 +197,18 @@ export default function HomePage() {
 				</div>
 			</section>
 
-			<section className="border-border bg-card border-b">
-				<div className="container-shell text-muted-foreground grid grid-cols-2 gap-4 py-5 text-sm font-bold md:grid-cols-4">
+			<section className="bg-card shadow-[inset_0_-1px_0_0_var(--border)]">
+				<div className="container-shell text-muted-foreground grid grid-cols-1 gap-3 py-4 text-sm font-bold sm:grid-cols-2 sm:gap-4 sm:py-5 md:grid-cols-4">
 					{[
 						"Family Owned & Operated",
 						"Licensed & Insured",
 						"Satisfaction Guaranteed",
 						"★★★★★ 4.9 Local Rating",
 					].map((item) => (
-						<span className="flex items-center justify-center gap-2" key={item}>
+						<span
+							className="flex items-center gap-2 sm:justify-center"
+							key={item}
+						>
 							<BadgeCheck className="text-primary size-4 shrink-0" />
 							{item}
 						</span>
@@ -285,7 +295,7 @@ export default function HomePage() {
 				<div className="container-shell">
 					<div className="flex flex-col justify-between gap-5 sm:flex-row sm:items-end">
 						<div className="max-w-2xl">
-							<Badge tone="inverse">Project Gallery</Badge>
+							<Badge tone="bright">Project Gallery</Badge>
 							<h2 className="type-title mt-5 text-white">
 								Real work from the Wade&apos;s team.
 							</h2>
@@ -296,7 +306,10 @@ export default function HomePage() {
 							</p>
 						</div>
 						<Link
-							className={buttonVariants({ variant: "inverse", size: "lg" })}
+							className={cn(
+								buttonVariants({ variant: "inverse", size: "lg" }),
+								"w-full sm:w-auto",
+							)}
 							href="/contact"
 							prefetch
 						>
@@ -454,7 +467,7 @@ export default function HomePage() {
 								],
 							].map(([quote, person]) => (
 								<blockquote
-									className="border-b border-white/10 pb-6 last:border-0 last:pb-0"
+									className="pb-6 shadow-[inset_0_-1px_0_0_rgba(255,255,255,0.08)] last:pb-0 last:shadow-none"
 									key={person}
 								>
 									<div className="text-primary-bright" aria-label="5 stars">
@@ -472,7 +485,7 @@ export default function HomePage() {
 						<Link
 							className={cn(
 								buttonVariants({ variant: "inverse", size: "lg" }),
-								"mt-8",
+								"mt-8 w-full sm:w-auto",
 							)}
 							href="/testimonials"
 							prefetch

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -31,9 +31,11 @@ export function ContactCta({
 				<div className="max-w-2xl">
 					<p className="type-eyebrow mb-3">Wade&apos;s Plumbing &amp; Septic</p>
 					<h2 className="type-title text-white">{title}</h2>
-					<p className="type-lead mt-3">{description}</p>
+					<p className="mt-3 text-base leading-relaxed text-[#e8e8e4] sm:text-lg">
+						{description}
+					</p>
 					{!compact ? (
-						<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-white/70">
+						<div className="mt-5 flex flex-wrap gap-x-5 gap-y-2 text-sm text-white/75">
 							<span className="inline-flex items-center gap-2">
 								<Clock className="text-primary-bright size-4" />
 								{siteConfig.hours}
@@ -51,12 +53,15 @@ export function ContactCta({
 
 				<div
 					className={cn(
-						"mt-7 flex flex-col gap-3 sm:flex-row",
-						!compact && "md:mt-0 md:shrink-0",
+						"mt-7 flex w-full max-w-md flex-col gap-3 sm:max-w-none sm:flex-row",
+						!compact && "md:mt-0 md:max-w-none md:shrink-0",
 					)}
 				>
 					<a
-						className={cn(buttonVariants({ size: "xl" }), "gap-2")}
+						className={cn(
+							buttonVariants({ size: "xl" }),
+							"w-full gap-2 sm:w-auto",
+						)}
 						href={siteConfig.phoneHref}
 					>
 						<Phone className="size-5" />
@@ -65,7 +70,7 @@ export function ContactCta({
 					<Link
 						className={cn(
 							buttonVariants({ variant: "inverse", size: "xl" }),
-							"gap-2",
+							"w-full gap-2 sm:w-auto",
 						)}
 						href="/contact"
 						prefetch

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -6,6 +6,7 @@ import { ChevronRight, Phone } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import { siteConfig } from "@/lib/site"
+import { cn } from "@/lib/utils"
 
 export function ContentHero({
 	title,
@@ -28,19 +29,20 @@ export function ContentHero({
 				<>
 					<Image
 						alt={imageAlt ?? ""}
-						className="object-cover opacity-30"
+						className="object-cover opacity-40"
 						fill
 						priority
 						quality={70}
 						sizes="100vw"
 						src={image}
 					/>
-					<div className="from-ink via-ink/90 to-ink/55 absolute inset-0 bg-linear-to-r" />
+					<div className="from-ink/75 via-ink/88 to-ink absolute inset-0 bg-linear-to-b" />
+					<div className="from-ink via-ink/70 to-ink/40 absolute inset-0 bg-linear-to-r" />
 				</>
 			) : null}
-			<div className="container-shell relative py-16 lg:py-20">
+			<div className="container-shell relative py-12 sm:py-16 lg:py-20">
 				<nav
-					className="mb-7 flex flex-wrap items-center gap-1 text-xs font-bold text-white/50"
+					className="header-muted mb-5 flex flex-wrap items-center gap-1 text-xs font-bold sm:mb-7"
 					aria-label="Breadcrumb"
 				>
 					<Link
@@ -52,7 +54,7 @@ export function ContentHero({
 					</Link>
 					{parent ? (
 						<>
-							<ChevronRight className="size-3" />
+							<ChevronRight className="size-3 opacity-70" />
 							<Link
 								className="transition-colors hover:text-white"
 								href={parent.href}
@@ -63,19 +65,26 @@ export function ContentHero({
 						</>
 					) : null}
 				</nav>
-				{eyebrow ? <Badge tone="inverse">{eyebrow}</Badge> : null}
-				<h1 className="type-display mt-5 max-w-4xl text-white">{title}</h1>
-				<p className="type-lead mt-5 max-w-3xl">{description}</p>
-				<div className="mt-8 flex flex-col gap-3 sm:flex-row">
+				{eyebrow ? <Badge tone="bright">{eyebrow}</Badge> : null}
+				<h1 className="type-display mt-4 max-w-4xl text-white sm:mt-5">
+					{title}
+				</h1>
+				<p className="mt-4 max-w-3xl text-base leading-relaxed text-[#e4e5e7] sm:mt-5 sm:text-lg">
+					{description}
+				</p>
+				<div className="mt-7 flex flex-col gap-3 sm:mt-8 sm:flex-row">
 					<a
-						className={buttonVariants({ size: "xl" })}
+						className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
 						href={siteConfig.phoneHref}
 					>
 						<Phone />
 						Call {siteConfig.phone}
 					</a>
 					<Link
-						className={buttonVariants({ variant: "inverse", size: "xl" })}
+						className={cn(
+							buttonVariants({ variant: "inverse", size: "xl" }),
+							"w-full sm:w-auto",
+						)}
 						href="/contact"
 						prefetch
 					>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -26,10 +26,10 @@ const serviceLinks = [
 export function SiteFooter() {
 	return (
 		<footer className="bg-ink text-white">
-			<div className="bg-primary border-b border-white/10">
+			<div className="bg-primary shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.18)]">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
-						<p className="text-sm font-bold text-white/80">
+						<p className="text-sm font-bold text-white/85">
 							24/7 Emergency Service
 						</p>
 						<p className="text-2xl font-extrabold tracking-[-0.03em]">
@@ -39,7 +39,7 @@ export function SiteFooter() {
 					<a
 						className={cn(
 							buttonVariants({ variant: "secondary", size: "lg" }),
-							"text-foreground gap-2 bg-white hover:bg-white/90",
+							"text-foreground w-full gap-2 bg-white hover:bg-white/90 sm:w-auto",
 						)}
 						href={siteConfig.phoneHref}
 					>
@@ -49,7 +49,7 @@ export function SiteFooter() {
 				</div>
 			</div>
 
-			<div className="container-shell py-16">
+			<div className="container-shell py-14 sm:py-16">
 				<div className="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
 					<div>
 						<Link
@@ -57,17 +57,21 @@ export function SiteFooter() {
 							href="/"
 							prefetch
 						>
-							<span className="grid size-12 place-items-center rounded-md bg-white p-1.5">
-								<Image
-									alt=""
-									height={40}
-									src="/images/brand/wades-mark.webp"
-									width={40}
-								/>
+							<Image
+								alt=""
+								className="size-11 shrink-0 rounded-md sm:size-12"
+								height={48}
+								src="/images/brand/wades-mark.webp"
+								width={48}
+							/>
+							<span className="leading-tight">
+								Wade&apos;s Plumbing
+								<span className="text-primary-bright mt-1 block text-[0.65rem] font-extrabold tracking-[0.18em] uppercase">
+									&amp; Septic
+								</span>
 							</span>
-							<span>Wade&apos;s Plumbing &amp; Septic</span>
 						</Link>
-						<p className="mt-4 text-sm leading-relaxed text-white/60">
+						<p className="mt-4 text-sm leading-relaxed text-white/65">
 							Family-owned plumbing and septic specialists. Honest
 							recommendations, clear pricing, and quality workmanship.
 						</p>
@@ -93,7 +97,7 @@ export function SiteFooter() {
 								},
 							].map((item) => (
 								<a
-									className="grid size-10 place-items-center rounded-md border border-white/12 text-white/55 transition-colors hover:border-white/30 hover:text-white"
+									className="grid size-10 place-items-center rounded-md bg-white/8 text-white/60 transition-colors hover:bg-white/14 hover:text-white"
 									href={item.href}
 									aria-label={item.label}
 									key={item.label}
@@ -111,7 +115,7 @@ export function SiteFooter() {
 					<FooterColumn title="Resources" links={resourceNavigation} />
 				</div>
 
-				<div className="mt-14 flex flex-col gap-4 border-t border-white/10 pt-7 text-xs text-white/45 sm:flex-row sm:items-center sm:justify-between">
+				<div className="mt-14 flex flex-col gap-4 pt-7 text-xs text-white/45 shadow-[inset_0_1px_0_0_rgba(255,255,255,0.06)] sm:flex-row sm:items-center sm:justify-between">
 					<p>© 2026 Wade&apos;s Plumbing &amp; Septic. All rights reserved.</p>
 					<div className="flex gap-5">
 						<Link

--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -141,88 +141,102 @@ export function SiteHeaderNav() {
 				</Button>
 			</div>
 
-			<Sheet>
-				<SheetTrigger asChild>
-					<Button
-						variant="inverse"
-						size="icon"
-						className="lg:hidden"
-						aria-label="Open main menu"
+			<div className="flex items-center gap-1 sm:gap-2 lg:hidden">
+				<Button
+					asChild
+					variant="ghost"
+					size="icon"
+					className="focus-visible:ring-offset-ink text-white hover:bg-white/10 hover:text-white sm:hidden"
+				>
+					<a
+						href={siteConfig.phoneHref}
+						aria-label={`Call ${siteConfig.phone}`}
 					>
-						<Menu aria-hidden="true" />
-					</Button>
-				</SheetTrigger>
-				<SheetContent side="right" className="bg-card">
-					<SheetHeader className="border-border border-b">
-						<div className="flex items-center gap-3">
-							<span className="border-border grid size-10 place-items-center rounded-md border bg-white p-1">
+						<Phone aria-hidden="true" className="size-5" />
+					</a>
+				</Button>
+				<Sheet>
+					<SheetTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="focus-visible:ring-offset-ink text-white hover:bg-white/10 hover:text-white"
+							aria-label="Open main menu"
+						>
+							<Menu aria-hidden="true" className="size-5" />
+						</Button>
+					</SheetTrigger>
+					<SheetContent side="right" className="bg-card">
+						<SheetHeader className="shadow-[inset_0_-1px_0_0_var(--border)]">
+							<div className="flex items-center gap-3">
 								<Image
 									alt=""
-									height={36}
+									className="size-10 rounded-md"
+									height={40}
 									src="/images/brand/wades-mark.webp"
-									width={36}
+									width={40}
 								/>
-							</span>
-							<div>
-								<SheetTitle>Wade&apos;s Plumbing &amp; Septic</SheetTitle>
-								<SheetDescription>Menu · {siteConfig.hours}</SheetDescription>
+								<div>
+									<SheetTitle>Wade&apos;s Plumbing &amp; Septic</SheetTitle>
+									<SheetDescription>Menu · {siteConfig.hours}</SheetDescription>
+								</div>
 							</div>
-						</div>
-					</SheetHeader>
+						</SheetHeader>
 
-					<nav
-						className="flex-1 overflow-y-auto px-2 py-3"
-						aria-label="Mobile navigation"
-					>
-						<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
-							Explore
-						</p>
-						{primaryNavLinks.map((item) => (
-							<MobileNavLink key={item.href} {...item} />
-						))}
-
-						<Separator className="my-3" />
-
-						<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
-							Services
-						</p>
-						{serviceNavLinks.map((item) => (
-							<MobileNavLink key={item.href} {...item} />
-						))}
-
-						<Separator className="my-3" />
-
-						<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
-							Company
-						</p>
-						{companyNavLinks.map((item) => (
-							<MobileNavLink key={item.href} {...item} />
-						))}
-					</nav>
-
-					<SheetFooter>
-						<a
-							className={cn(buttonVariants({ size: "lg" }), "w-full gap-2")}
-							href={siteConfig.phoneHref}
+						<nav
+							className="flex-1 overflow-y-auto px-2 py-3"
+							aria-label="Mobile navigation"
 						>
-							<Phone aria-hidden="true" />
-							Call {siteConfig.phone}
-						</a>
-						<SheetClose asChild>
-							<Link
-								className={cn(
-									buttonVariants({ variant: "outline", size: "lg" }),
-									"w-full",
-								)}
-								href={"/contact" as Route}
-								prefetch
+							<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
+								Explore
+							</p>
+							{primaryNavLinks.map((item) => (
+								<MobileNavLink key={item.href} {...item} />
+							))}
+
+							<Separator className="my-3" />
+
+							<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
+								Services
+							</p>
+							{serviceNavLinks.map((item) => (
+								<MobileNavLink key={item.href} {...item} />
+							))}
+
+							<Separator className="my-3" />
+
+							<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
+								Company
+							</p>
+							{companyNavLinks.map((item) => (
+								<MobileNavLink key={item.href} {...item} />
+							))}
+						</nav>
+
+						<SheetFooter>
+							<a
+								className={cn(buttonVariants({ size: "lg" }), "w-full gap-2")}
+								href={siteConfig.phoneHref}
 							>
-								Get a Free Quote
-							</Link>
-						</SheetClose>
-					</SheetFooter>
-				</SheetContent>
-			</Sheet>
+								<Phone aria-hidden="true" />
+								Call {siteConfig.phone}
+							</a>
+							<SheetClose asChild>
+								<Link
+									className={cn(
+										buttonVariants({ variant: "outline", size: "lg" }),
+										"w-full",
+									)}
+									href={"/contact" as Route}
+									prefetch
+								>
+									Get a Free Quote
+								</Link>
+							</SheetClose>
+						</SheetFooter>
+					</SheetContent>
+				</Sheet>
+			</div>
 		</>
 	)
 }

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -6,8 +6,8 @@ import { siteConfig } from "@/lib/site"
 
 export function SiteHeader() {
 	return (
-		<header className="bg-ink sticky top-0 z-50 border-b border-white/15 text-white">
-			<div className="bg-ink-soft hidden border-b border-white/15 sm:block">
+		<header className="bg-ink sticky top-0 z-50 text-white shadow-[0_1px_0_0_rgba(0,0,0,0.45)]">
+			<div className="bg-ink-soft hidden sm:block">
 				<div className="container-shell header-muted flex items-center justify-between py-2 text-xs font-semibold">
 					<span>{siteConfig.hours}</span>
 					<Link
@@ -20,27 +20,26 @@ export function SiteHeader() {
 				</div>
 			</div>
 
-			<div className="container-shell flex h-18 items-center justify-between gap-4">
+			<div className="container-shell flex h-16 items-center justify-between gap-3 sm:h-18">
 				<Link
-					className="flex min-w-0 items-center gap-3"
+					className="flex min-w-0 items-center gap-2.5 sm:gap-3"
 					href="/"
 					aria-label="Wade's Plumbing & Septic home"
 					prefetch
 				>
-					<span className="grid size-11 shrink-0 place-items-center rounded-md bg-white p-1">
-						<Image
-							alt=""
-							height={40}
-							priority
-							src="/images/brand/wades-mark.webp"
-							width={40}
-						/>
-					</span>
+					<Image
+						alt=""
+						className="size-10 rounded-md sm:size-11"
+						height={44}
+						priority
+						src="/images/brand/wades-mark.webp"
+						width={44}
+					/>
 					<span className="leading-none">
-						<span className="block text-base font-extrabold tracking-[-0.03em] text-white sm:text-lg">
+						<span className="block text-[0.95rem] font-extrabold tracking-[-0.03em] text-white sm:text-lg">
 							Wade&apos;s Plumbing
 						</span>
-						<span className="text-primary-bright mt-1 block text-[0.68rem] font-extrabold tracking-[0.18em] uppercase">
+						<span className="text-primary-bright mt-1 block text-[0.65rem] font-extrabold tracking-[0.18em] uppercase">
 							&amp; Septic
 						</span>
 					</span>

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -4,15 +4,14 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 export const badgeVariants = cva(
-	"inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-[0.7rem] font-extrabold tracking-[0.14em] uppercase",
+	"inline-flex items-center gap-2 rounded-md px-2.5 py-1 text-[0.7rem] font-extrabold tracking-[0.14em] uppercase",
 	{
 		variants: {
 			tone: {
-				default: "border-primary/25 bg-accent text-accent-foreground",
-				bright:
-					"border-primary-bright/35 bg-primary-bright/12 text-primary-bright",
-				muted: "border-border bg-muted text-muted-foreground",
-				inverse: "border-white/20 bg-white/8 text-white",
+				default: "bg-accent text-accent-foreground",
+				bright: "bg-primary-bright/15 text-primary-bright",
+				muted: "bg-muted text-muted-foreground",
+				inverse: "bg-primary-bright/15 text-primary-bright",
 			},
 		},
 		defaultVariants: {

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 export const buttonVariants = cva(
-	"inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-bold whitespace-nowrap transition-[color,background-color,border-color,transform] duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:translate-y-px",
+	"inline-flex shrink-0 items-center justify-center gap-2 rounded-md border border-transparent text-sm font-bold whitespace-nowrap transition-[color,background-color,border-color,transform] duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:translate-y-px",
 	{
 		variants: {
 			variant: {
@@ -14,11 +14,11 @@ export const buttonVariants = cva(
 				secondary:
 					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_srgb,var(--secondary)_85%,var(--ink))]",
 				outline:
-					"border border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
+					"border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
 				ghost: "text-foreground hover:bg-muted",
 				link: "text-primary underline-offset-4 hover:underline",
 				inverse:
-					"border border-white/35 bg-white/12 text-white hover:border-white/55 hover:bg-white/18",
+					"border-transparent bg-white/12 text-white hover:bg-white/18 focus-visible:ring-offset-ink",
 			},
 			size: {
 				default: "h-11 px-4 py-2",

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -88,7 +88,7 @@ export function SheetFooter({
 	return (
 		<div
 			className={cn(
-				"border-border mt-auto flex flex-col gap-3 border-t p-5",
+				"mt-auto flex flex-col gap-3 p-5 shadow-[inset_0_1px_0_0_var(--border)]",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Continues design polish after the header rebuild. Removes the harsh white/light hairline borders on dark surfaces and improves mobile readability and CTA layout.

## Changes
- **Buttons / badges:** Inverse CTAs and badges no longer use white outline borders; dark accents use copper tint fills instead
- **Header:** Drop white bottom border and logo white plate; ghost menu trigger; mobile call icon beside menu
- **Heroes:** Stronger ink overlays, brighter body copy, full-width stacked CTAs on small screens
- **Footer / CTA:** Soft inset dividers instead of `border-white/*`; logo without white box; filled social icons
- **Sheet:** Soft separators instead of hard hairlines

## Verification
- `npm run check` passed (lint, typecheck, format, build)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

