### PR TITLE
Remove all 24/7 emergency company claims

### DIFF
--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -20,7 +20,7 @@ const categories = {
 		label: "Residential Plumbing",
 		contentCategory: "Plumbing",
 		description:
-			"Complete plumbing service for homes, including repairs, replacements, maintenance, and emergency response.",
+			"Complete plumbing service for homes, including repairs, replacements, maintenance, and urgent repairs.",
 		image: "/images/services/drain-clearing.webp",
 	},
 	commercial: {
@@ -52,10 +52,10 @@ const categories = {
 		image: "/images/work/completed-multi-tank.webp",
 	},
 	"emergency-services": {
-		label: "Emergency Services",
+		label: "Urgent Repairs",
 		contentCategory: "Plumbing",
 		description:
-			"Call-first support for active leaks, burst pipes, sewer backups, failed water heaters, and urgent plumbing problems.",
+			"Call-first support during business hours for active leaks, burst pipes, sewer backups, failed water heaters, and other time-sensitive plumbing problems.",
 		image: "/images/work/drain-cleaning-equipment.webp",
 	},
 	"specialty-services": {

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -30,7 +30,7 @@ export function SiteFooter() {
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
 						<p className="text-sm font-bold text-white/85">
-							24/7 Emergency Service
+							{siteConfig.hours}
 						</p>
 						<p className="text-2xl font-extrabold tracking-[-0.03em]">
 							{siteConfig.phone}

--- a/content/pages/careers/licensed-plumber.md
+++ b/content/pages/careers/licensed-plumber.md
@@ -14,7 +14,7 @@ Wade’s Plumbing & Septic is seeking licensed plumbers to join our growing team
 
 - Diagnose and repair plumbing systems and fixtures
 - Install new plumbing systems in residential and commercial settings
-- Respond to service calls and emergency situations
+- Respond to service calls and time-sensitive repairs
 - Maintain accurate records of work performed
 - Provide estimates for repairs and installations
 - Ensure all work meets applicable codes and standards

--- a/content/pages/contact-call-first.md
+++ b/content/pages/contact-call-first.md
@@ -19,4 +19,4 @@ For the fastest help, call with:
 
 The team will confirm coverage, recommend the right service path, and provide the next available scheduling options.
 
-Regular office hours are Monday through Friday, 9:00 AM–5:00 PM. Emergency calls are answered 24/7.
+Regular office hours are Monday through Friday, 9:00 AM–5:00 PM. Call 831.225.4344 to schedule service.

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -1,7 +1,7 @@
 ---
 title: Get in Touch with Wade's Plumbing
 description: Contact Wade's Plumbing & Septic for professional plumbing and septic service across Santa Cruz County and Santa Clara County.
-eyebrow: Available 24/7 for Emergencies
+eyebrow: Call During Business Hours
 image: /images/team/wades-team.webp
 imageAlt: Professional Wade's plumber at work
 order: 7
@@ -9,7 +9,7 @@ order: 7
 
 ## Let's solve your plumbing or septic problem
 
-We respond during business hours and answer urgent emergency calls around the clock.
+We respond during business hours, Monday through Friday from 9:00 AM to 5:00 PM.
 
 ### Call or text
 
@@ -21,8 +21,7 @@ We respond during business hours and answer urgent emergency calls around the cl
 
 ### Business hours
 
-Monday–Friday, 9:00 AM–5:00 PM  
-24/7 emergency availability
+Monday–Friday, 9:00 AM–5:00 PM
 
 ### Service area
 

--- a/content/pages/downloads.md
+++ b/content/pages/downloads.md
@@ -1,6 +1,6 @@
 ---
 title: Homeowner Plumbing & Septic Downloads
-description: Save practical Wade's maintenance checklists, emergency information, and project preparation guidance.
+description: Save practical Wade's maintenance checklists, urgent-repair guidance, and project preparation tips.
 eyebrow: Useful Resources
 image: /images/services/septic-pumping-illustration.webp
 imageAlt: Septic pumping and maintenance illustration
@@ -10,7 +10,7 @@ imageAlt: Septic pumping and maintenance illustration
 
 This resource center collects the same core guidance used throughout our homeowner articles.
 
-### Emergency plumbing checklist
+### Urgent plumbing checklist
 
 1. Shut off water at the nearest working valve or the building main.
 2. Keep people and electricity away from wet areas.

--- a/content/pages/emergency-plumber-santa-cruz-county.md
+++ b/content/pages/emergency-plumber-santa-cruz-county.md
@@ -1,9 +1,9 @@
 ---
 title: Emergency Plumber Near You in Santa Cruz County
 description: Call for immediate triage of burst pipes, active leaks, sewer backups, failed water heaters, and urgent plumbing or septic problems.
-eyebrow: 24/7 Emergency Response
+eyebrow: Urgent Plumbing Help
 image: /images/work/drain-cleaning-equipment.webp
-imageAlt: Exposed emergency plumbing repair
+imageAlt: Exposed plumbing repair work
 noindex: true
 ---
 

--- a/content/pages/faq.md
+++ b/content/pages/faq.md
@@ -1,6 +1,6 @@
 ---
 title: Frequently Asked Questions
-description: Straight answers about plumbing, septic systems, service areas, pricing, scheduling, licensing, and emergency response.
+description: Straight answers about plumbing, septic systems, service areas, pricing, scheduling, licensing, and urgent repairs.
 eyebrow: Helpful Answers
 order: 4
 ---
@@ -41,7 +41,7 @@ We serve Santa Cruz County, selected Santa Clara County communities, and Pickens
 
 ### How do I schedule service?
 
-Call 831.225.4344 during regular hours, Monday–Friday from 9:00 AM–5:00 PM. Emergency calls are answered 24/7.
+Call 831.225.4344 during regular hours, Monday–Friday from 9:00 AM–5:00 PM.
 
 ### Do you offer financing?
 
@@ -51,9 +51,9 @@ Financing may be available for qualified larger projects. Visit the [financing p
 
 Yes. California CSLB #1087260 includes C-36 plumbing and C-42 sanitation system classifications. Georgia master plumber license MPR108559 is also held.
 
-### Do you provide emergency service?
+### Do you provide urgent repair service?
 
-Yes. Emergency plumbing and septic calls are answered 24/7, including weekends and holidays. Call 831.225.4344 for the fastest response.
+Yes. Call 831.225.4344 during business hours, Monday–Friday from 9:00 AM–5:00 PM, and we will help prioritize time-sensitive leaks, backups, and septic issues.
 
 ### Do you work on engineered or alternative septic systems?
 

--- a/content/pages/santa-cruz.md
+++ b/content/pages/santa-cruz.md
@@ -23,7 +23,7 @@ Wade's serves Santa Cruz, Capitola, Soquel, Aptos, Scotts Valley, Watsonville, t
 
 ## Plumbing services
 
-Drain cleaning, hydro jetting, leak detection, pipe repair, water heaters, fixtures, water treatment, sewer cameras, trenchless replacement, remodel plumbing, commercial service, and emergency response.
+Drain cleaning, hydro jetting, leak detection, pipe repair, water heaters, fixtures, water treatment, sewer cameras, trenchless replacement, remodel plumbing, commercial service, and urgent repairs.
 
 ## Septic services
 

--- a/content/pages/service-area/amesti-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/amesti-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Amesti, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Amesti, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Amesti, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Amesti
 

--- a/content/pages/service-area/aptos-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/aptos-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Aptos, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Aptos, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Aptos, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Aptos
 

--- a/content/pages/service-area/aptos-hills-larkin-valley-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/aptos-hills-larkin-valley-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Aptos Hills-Larkin Valley, Cal
 order: 50
 ---
 
-Need trusted plumbing and septic service in Aptos Hills-Larkin Valley, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Aptos Hills-Larkin Valley, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Aptos Hills-Larkin Valley
 

--- a/content/pages/service-area/ben-lomond-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/ben-lomond-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Ben Lomond, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Ben Lomond, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Ben Lomond, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Ben Lomond
 

--- a/content/pages/service-area/bonny-doon-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/bonny-doon-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Bonny Doon, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Bonny Doon, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Bonny Doon, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Bonny Doon
 

--- a/content/pages/service-area/boulder-creek-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/boulder-creek-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Boulder Creek, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Boulder Creek, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Boulder Creek, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Boulder Creek
 

--- a/content/pages/service-area/brookdale-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/brookdale-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Brookdale, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Brookdale, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Brookdale, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Brookdale
 

--- a/content/pages/service-area/capitola-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/capitola-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Capitola, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Capitola, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Capitola, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Capitola
 

--- a/content/pages/service-area/corralitos-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/corralitos-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Corralitos, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Corralitos, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Corralitos, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Corralitos
 

--- a/content/pages/service-area/davenport-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/davenport-ca-plumbing-septic-services.md
@@ -17,7 +17,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Davenport
 

--- a/content/pages/service-area/day-valley-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/day-valley-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Day Valley, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Day Valley, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Day Valley, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Day Valley
 

--- a/content/pages/service-area/felton-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/felton-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Felton, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Felton, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Felton, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Felton
 

--- a/content/pages/service-area/freedom-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/freedom-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Freedom, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Freedom, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Freedom, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Freedom
 

--- a/content/pages/service-area/interlaken-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/interlaken-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Interlaken, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Interlaken, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Interlaken, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Interlaken
 

--- a/content/pages/service-area/la-selva-beach-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/la-selva-beach-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in La Selva Beach, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in La Selva Beach, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in La Selva Beach, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in La Selva Beach
 

--- a/content/pages/service-area/las-lomas-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/las-lomas-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Las Lomas, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Las Lomas, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Las Lomas, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Las Lomas
 

--- a/content/pages/service-area/live-oak-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/live-oak-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Live Oak, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Live Oak, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Live Oak, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Live Oak
 

--- a/content/pages/service-area/lompico-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/lompico-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Lompico, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Lompico, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Lompico, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Lompico
 

--- a/content/pages/service-area/los-gatos-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/los-gatos-ca-plumbing-septic-services.md
@@ -17,7 +17,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Los Gatos
 

--- a/content/pages/service-area/mount-hermon-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/mount-hermon-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Mount Hermon, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Mount Hermon, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Mount Hermon, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Mount Hermon
 

--- a/content/pages/service-area/paradise-park-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/paradise-park-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Paradise Park, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Paradise Park, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Paradise Park, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Paradise Park
 

--- a/content/pages/service-area/pasatiempo-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/pasatiempo-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Pasatiempo, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Pasatiempo, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Pasatiempo, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Pasatiempo
 

--- a/content/pages/service-area/rio-del-mar-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/rio-del-mar-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Rio Del Mar, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Rio Del Mar, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Rio Del Mar, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Rio Del Mar
 

--- a/content/pages/service-area/santa-cruz-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/santa-cruz-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Santa Cruz, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Santa Cruz, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Santa Cruz, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Santa Cruz
 

--- a/content/pages/service-area/saratoga-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/saratoga-ca-plumbing-septic-services.md
@@ -17,7 +17,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Saratoga
 

--- a/content/pages/service-area/scotts-valley-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/scotts-valley-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Scotts Valley, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Scotts Valley, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Scotts Valley, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Scotts Valley
 

--- a/content/pages/service-area/soquel-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/soquel-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Soquel, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Soquel, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Soquel, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Soquel
 

--- a/content/pages/service-area/twin-lakes-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/twin-lakes-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Twin Lakes, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Twin Lakes, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Twin Lakes, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Twin Lakes
 

--- a/content/pages/service-area/watsonville-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/watsonville-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Watsonville, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Watsonville, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Watsonville, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Watsonville
 

--- a/content/pages/service-area/zayante-ca-plumbing-septic-services.md
+++ b/content/pages/service-area/zayante-ca-plumbing-septic-services.md
@@ -7,7 +7,7 @@ imageAlt: Plumbing and septic service coverage in Zayante, California
 order: 50
 ---
 
-Need trusted plumbing and septic service in Zayante, CA? Wade’s provides fast diagnostics, maintenance, and emergency support for homeowners.
+Need trusted plumbing and septic service in Zayante, CA? Wade’s provides fast diagnostics, maintenance, and repair support for homeowners.
 
 _Service region:_ Santa Cruz County, California
 
@@ -19,7 +19,7 @@ Local homes and businesses call Wade's for:
 - Drain cleaning, hydro-jetting, and camera inspections
 - Water heater and tankless water heater work
 - Fixture, toilet, and shower repairs
-- Emergency plumbing response when available
+- Priority repair scheduling when available
 
 ## Septic services in Zayante
 

--- a/content/pages/service-areas.md
+++ b/content/pages/service-areas.md
@@ -1,6 +1,6 @@
 ---
 title: Plumbing & Septic Service Areas
-description: Wade's serves Santa Cruz County, selected Santa Clara County communities, and Pickens County, Georgia, with emergency availability.
+description: Wade's serves Santa Cruz County, selected Santa Clara County communities, and Pickens County, Georgia.
 eyebrow: Local Coverage
 image: /images/locations/santa-cruz-redwoods.webp
 imageAlt: Coastal redwoods in the Santa Cruz County service area
@@ -93,4 +93,4 @@ Explore the [Pickens County plumbing page](/pickens-county-ga).
 3. **Schedule the right visit.** The team matches the work with the appropriate technician or project lead.
 4. **Get clear options.** The property is evaluated and pricing is provided before authorized work begins.
 
-Regular hours are Monday through Friday, 9:00 AM–5:00 PM. Emergency plumbing and septic calls are answered 24/7.
+Regular hours are Monday through Friday, 9:00 AM–5:00 PM. Call 831.225.4344 to confirm coverage and schedule service.

--- a/content/pages/thank-you.md
+++ b/content/pages/thank-you.md
@@ -13,7 +13,7 @@ Thanks for reaching out to Wade's Plumbing & Septic. A real person on our team w
 
 ### Need help right now?
 
-Call or text [831.225.4344](tel:+18312254344). Emergency plumbing and septic calls are answered 24/7.
+Call or text [831.225.4344](tel:+18312254344) during business hours, Monday through Friday from 9:00 AM to 5:00 PM.
 
 ### While you wait
 

--- a/content/posts/emergency-septic-solutions-santa-cruz.md
+++ b/content/posts/emergency-septic-solutions-santa-cruz.md
@@ -95,6 +95,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/how-santa-cruz-countys-unique-geography-affects-septic-systems.md
+++ b/content/posts/how-santa-cruz-countys-unique-geography-affects-septic-systems.md
@@ -80,7 +80,7 @@ Our team holds a C-42 license for California and a state license for Georgia, en
 
 Office Hours: Monday to Friday, 9am–5pm
 
-Emergency Line: Available 24/7 for urgent septic issues
+Phone: 831.225.4344 · Monday–Friday, 9am–5pm
 
 For more information on our service areas, visit our [main service-area overview](/service-areas/).
 
@@ -95,6 +95,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/seasonal-septic-maintenance-santa-cruz.md
+++ b/content/posts/seasonal-septic-maintenance-santa-cruz.md
@@ -93,6 +93,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-leach-field-repairs-santa-cruz.md
+++ b/content/posts/septic-leach-field-repairs-santa-cruz.md
@@ -90,7 +90,7 @@ Our contractors are fully licensed with a C-42 license for California and a stat
 
 Office Hours: Monday – Friday, 9am – 5pm
 
-Emergency Line: Available 24/7 for urgent septic system needs.
+Phone: 831.225.4344 · Monday–Friday, 9am–5pm
 
 For more information on our service areas, visit our [main service-area overview](/service-areas/).
 
@@ -105,6 +105,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-pumping-essentials-santa-cruz.md
+++ b/content/posts/septic-pumping-essentials-santa-cruz.md
@@ -108,7 +108,7 @@ At Wade’s Plumbing & Septic, we proudly serve the communities of Santa Cruz Co
 
 We are a licensed contractor with a C-42 license for California, ensuring that all our services meet the highest standards of quality and compliance.
 
-Our office hours are Monday through Friday, 9am to 5pm. For your convenience, we also offer an emergency line available 24/7 to address any urgent septic issues.
+Our office hours are Monday through Friday, 9am to 5pm. Call 831.225.4344 during business hours for help with urgent septic issues.
 
 For more information on our service areas, please visit our [service area overview](/service-areas/).
 
@@ -123,6 +123,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-safety-during-floods-santa-cruz.md
+++ b/content/posts/septic-safety-during-floods-santa-cruz.md
@@ -101,7 +101,7 @@ Contact Wade's Plumbing & Septic for expert advice and services to protect your 
 
 At Wade’s Plumbing & Septic, we proudly serve the entire Santa Cruz County, including communities such as [Aptos](/service-area/aptos/), [Capitola](/service-area/capitola/), [Santa Cruz](/service-area/santa-cruz/), and [Scotts Valley](/service-area/scotts-valley/). We are licensed under the C-42 classification in California and hold a state license in Georgia, ensuring our expertise and compliance with all local regulations.
 
-Our office hours are Monday through Friday, from 9am to 5pm. For urgent needs, our emergency line is available 24/7, providing you with peace of mind no matter the time of day.
+Our office hours are Monday through Friday, from 9am to 5pm. Call 831.225.4344 during business hours for help with urgent septic needs.
 
 For a complete overview of our service areas, please visit our [main service-area page](/service-areas/).
 
@@ -116,6 +116,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-system-components-santa-cruz-2.md
+++ b/content/posts/septic-system-components-santa-cruz-2.md
@@ -80,7 +80,7 @@ At Wade’s Plumbing & Septic, we proudly serve the entire Santa Cruz County, in
 
 Office Hours: Monday to Friday, 9am–5pm
 
-Emergency Line: Available 24/7
+Phone: 831.225.4344 · Monday–Friday, 9am–5pm
 
 For a complete overview of our service areas, please visit our [service area page](/service-areas/).
 
@@ -95,6 +95,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-system-components-santa-cruz.md
+++ b/content/posts/septic-system-components-santa-cruz.md
@@ -111,6 +111,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-system-seasonal-maintenance-santa-cruz.md
+++ b/content/posts/septic-system-seasonal-maintenance-santa-cruz.md
@@ -129,6 +129,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-system-types-santa-cruz.md
+++ b/content/posts/septic-system-types-santa-cruz.md
@@ -123,6 +123,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/septic-trouble-signs-santa-cruz.md
+++ b/content/posts/septic-trouble-signs-santa-cruz.md
@@ -92,7 +92,7 @@ At Wade’s Plumbing & Septic, we proudly serve the entire Santa Cruz County are
 
 We are fully licensed and insured, holding a C-42 license in California and a state license in Georgia, which assures our clients of our professional standards and commitment to quality service.
 
-Our office hours are Monday through Friday, 9am to 5pm. For your convenience, we also offer an emergency line available 24/7 to address any urgent septic issues you may encounter.
+Our office hours are Monday through Friday, 9am to 5pm. Call 831.225.4344 during business hours for help with urgent septic issues.
 
 For more information on the areas we serve, please visit our [service area overview page](/service-areas/).
 
@@ -107,6 +107,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/sewer-line-repair-essentials-santa-cruz.md
+++ b/content/posts/sewer-line-repair-essentials-santa-cruz.md
@@ -93,6 +93,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/content/posts/understanding-the-cost-of-septic-pumping-in-santa-cruz-county.md
+++ b/content/posts/understanding-the-cost-of-septic-pumping-in-santa-cruz-county.md
@@ -21,7 +21,7 @@ Septic pumping prices vary because systems and access conditions vary. A useful 
 - Volume and type of material removed
 - Disposal charges
 - Filter cleaning or component inspection
-- Emergency or after-hours scheduling
+- Priority scheduling for urgent issues during business hours
 
 ## Ask what the service includes
 

--- a/content/posts/urgent-septic-failure-signs-santa-cruz.md
+++ b/content/posts/urgent-septic-failure-signs-santa-cruz.md
@@ -70,7 +70,7 @@ At Wade’s Plumbing & Septic, we proudly serve the entire Santa Cruz County, in
 
 We are a licensed contractor with a C-42 license for California, ensuring that you receive the highest quality service from certified professionals.
 
-Our office hours are Monday through Friday, 9am to 5pm. For urgent issues, our emergency line is available 24/7 to provide you with immediate assistance.
+Our office hours are Monday through Friday, 9am to 5pm. Call 831.225.4344 during business hours for help with urgent septic issues.
 
 For more information on our service areas, please visit our [service area overview](/service-areas/).
 
@@ -105,6 +105,6 @@ Need help with this issue?
 
 ## Talk to a local expert
 
-Tell us what is going on and we will follow up with straight answers and scheduling options. For emergencies, call us directly.
+Tell us what is going on and we will follow up with straight answers and scheduling options. For urgent issues, call us during business hours.
 
 [ Call 831.225.4344 ](tel:8312254344) [Full quote form](/contact/)

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -27,8 +27,9 @@ export const serviceNavLinks: NavLink[] = [
 	},
 	{
 		href: "/service-category/emergency-services",
-		label: "Emergency Service",
-		description: "Urgent leaks, backups, and after-hours response.",
+		label: "Urgent Repairs",
+		description:
+			"Priority help for leaks, backups, and time-sensitive repairs.",
 	},
 ]
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts"
-import "./.next/types/root-params.d.ts"
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Removes every claim that Wade’s is a 24/7 emergency company. Scheduling and contact copy now consistently reflect Monday–Friday business hours.

## Changes
- **Footer CTA:** “24/7 Emergency Service” → business hours from `siteConfig`
- **Nav / category:** “Emergency Service” → “Urgent Repairs” (business-hours priority help)
- **Contact, FAQ, thank-you, service-areas:** no more 24/7 / around-the-clock claims
- **~30 city pages:** emergency bullet → priority repair scheduling
- **Blog posts:** emergency-line 24/7 blurbs → call during business hours
- **Kept:** safety copy that tells people to contact 911 / the gas utility in true emergencies

## Verification
- Repo scan shows no remaining `24/7`, `after-hours`, or “emergency availability” company claims
- `npm run check` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

