### PR TITLE
Fix real cause of “white borders” on dark CTAs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -199,7 +199,7 @@ export default function HomePage() {
 							No sales pressure. No upselling. Clear pricing before work begins
 							from local licensed professionals.
 						</p>
-						<div className="motion-rise motion-delay-2 mt-7 flex w-full max-w-md flex-col gap-3 sm:mt-8 sm:max-w-none sm:flex-row">
+						<div className="motion-rise motion-delay-2 mt-7 flex w-full max-w-md flex-col items-stretch gap-4 sm:mt-8 sm:max-w-none sm:flex-row sm:items-center">
 							<a
 								className={cn(
 									buttonVariants({ size: "xl" }),
@@ -216,7 +216,7 @@ export default function HomePage() {
 										variant: "inverse",
 										size: "xl",
 									}),
-									"w-full sm:w-auto",
+									"w-full justify-start sm:w-auto sm:justify-center",
 								)}
 								href="/services"
 								prefetch
@@ -340,7 +340,7 @@ export default function HomePage() {
 						<Link
 							className={cn(
 								buttonVariants({ variant: "inverse", size: "lg" }),
-								"w-full sm:w-auto",
+								"w-full justify-start sm:w-auto sm:justify-center",
 							)}
 							href="/contact"
 							prefetch
@@ -517,7 +517,7 @@ export default function HomePage() {
 						<Link
 							className={cn(
 								buttonVariants({ variant: "inverse", size: "lg" }),
-								"mt-8 w-full sm:w-auto",
+								"mt-8 w-full justify-start sm:w-auto sm:justify-center",
 							)}
 							href="/testimonials"
 							prefetch

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -53,7 +53,7 @@ export function ContactCta({
 
 				<div
 					className={cn(
-						"mt-7 flex w-full max-w-md flex-col gap-3 sm:max-w-none sm:flex-row",
+						"mt-7 flex w-full max-w-md flex-col items-stretch gap-4 sm:max-w-none sm:flex-row sm:items-center",
 						!compact && "md:mt-0 md:max-w-none md:shrink-0",
 					)}
 				>
@@ -70,7 +70,7 @@ export function ContactCta({
 					<Link
 						className={cn(
 							buttonVariants({ variant: "inverse", size: "xl" }),
-							"w-full gap-2 sm:w-auto",
+							"w-full justify-start gap-2 sm:w-auto sm:justify-center",
 						)}
 						href="/contact"
 						prefetch

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -72,7 +72,7 @@ export function ContentHero({
 				<p className="mt-4 max-w-3xl text-base leading-relaxed text-[#e4e5e7] sm:mt-5 sm:text-lg">
 					{description}
 				</p>
-				<div className="mt-7 flex flex-col gap-3 sm:mt-8 sm:flex-row">
+				<div className="mt-7 flex flex-col items-stretch gap-4 sm:mt-8 sm:flex-row sm:items-center">
 					<a
 						className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
 						href={siteConfig.phoneHref}
@@ -83,7 +83,7 @@ export function ContentHero({
 					<Link
 						className={cn(
 							buttonVariants({ variant: "inverse", size: "xl" }),
-							"w-full sm:w-auto",
+							"w-full justify-start sm:w-auto sm:justify-center",
 						)}
 						href="/contact"
 						prefetch

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -97,7 +97,7 @@ export function SiteFooter() {
 								},
 							].map((item) => (
 								<a
-									className="grid size-10 place-items-center rounded-md bg-white/8 text-white/60 transition-colors hover:bg-white/14 hover:text-white"
+									className="hover:text-primary-bright grid size-10 place-items-center text-white/60 transition-colors"
 									href={item.href}
 									aria-label={item.label}
 									key={item.label}

--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -93,7 +93,7 @@ export function SiteHeaderNav() {
 								<Link
 									className={cn(
 										navigationMenuTriggerStyle(),
-										"bg-transparent text-white hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white data-[active]:bg-white/10",
+										"hover:text-primary-bright focus:text-primary-bright data-[active]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[active]:bg-transparent",
 									)}
 									href={item.href as Route}
 									prefetch
@@ -105,7 +105,7 @@ export function SiteHeaderNav() {
 					))}
 
 					<NavigationMenuItem>
-						<NavigationMenuTrigger className="bg-transparent text-white hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white data-[state=open]:bg-white/12 data-[state=open]:text-white">
+						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
 							Services
 						</NavigationMenuTrigger>
 						<NavigationMenuContent>
@@ -118,7 +118,7 @@ export function SiteHeaderNav() {
 					</NavigationMenuItem>
 
 					<NavigationMenuItem>
-						<NavigationMenuTrigger className="bg-transparent text-white hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white data-[state=open]:bg-white/12 data-[state=open]:text-white">
+						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
 							Company
 						</NavigationMenuTrigger>
 						<NavigationMenuContent>
@@ -141,12 +141,12 @@ export function SiteHeaderNav() {
 				</Button>
 			</div>
 
-			<div className="flex items-center gap-1 sm:gap-2 lg:hidden">
+			<div className="flex items-center lg:hidden">
 				<Button
 					asChild
 					variant="ghost"
 					size="icon"
-					className="focus-visible:ring-offset-ink text-white hover:bg-white/10 hover:text-white sm:hidden"
+					className="hover:text-primary-bright focus-visible:ring-offset-ink text-white hover:bg-transparent sm:hidden"
 				>
 					<a
 						href={siteConfig.phoneHref}
@@ -160,7 +160,7 @@ export function SiteHeaderNav() {
 						<Button
 							variant="ghost"
 							size="icon"
-							className="focus-visible:ring-offset-ink text-white hover:bg-white/10 hover:text-white"
+							className="hover:text-primary-bright focus-visible:ring-offset-ink text-white hover:bg-transparent"
 							aria-label="Open main menu"
 						>
 							<Menu aria-hidden="true" className="size-5" />

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,20 +5,25 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 export const buttonVariants = cva(
-	"inline-flex shrink-0 items-center justify-center gap-2 rounded-md border-0 text-sm font-bold whitespace-nowrap transition-[color,background-color,border-color,transform] duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:translate-y-px",
+	"inline-flex shrink-0 items-center justify-center gap-2 rounded-md border-0 shadow-none text-sm font-bold whitespace-nowrap transition-[color,background-color,transform,opacity] duration-150 outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-45 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 active:translate-y-px",
 	{
 		variants: {
 			variant: {
 				default:
-					"bg-primary text-primary-foreground hover:bg-[color-mix(in_srgb,var(--primary)_88%,black)]",
+					"bg-primary text-primary-foreground shadow-[inset_0_0_0_1px_rgba(0,0,0,0.22)] hover:bg-[color-mix(in_srgb,var(--primary)_88%,black)]",
 				secondary:
 					"bg-secondary text-secondary-foreground hover:bg-[color-mix(in_srgb,var(--secondary)_85%,var(--ink))]",
 				outline:
 					"border border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
-				ghost: "bg-transparent text-foreground hover:bg-muted",
+				ghost:
+					"bg-transparent text-foreground hover:bg-transparent hover:text-primary",
 				link: "bg-transparent text-primary underline-offset-4 hover:underline",
+				/**
+				 * Dark-surface secondary CTA. No fill plate — light translucent
+				 * backgrounds create hard edges that read as white borders on ink.
+				 */
 				inverse:
-					"bg-white/12 text-white hover:bg-white/18 focus-visible:ring-offset-ink",
+					"bg-transparent px-0 text-white hover:bg-transparent hover:text-primary-bright focus-visible:ring-offset-ink",
 			},
 			size: {
 				default: "h-11 px-4 py-2",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/types/routes.d.ts"
+import "./.next/types/root-params.d.ts"
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What was actually wrong
Production already had `border-width: 0`. The “white borders” were **hard edges from light fills** (`bg-white/12`, `hover:bg-white/10`) sitting on black ink — those plates look like outlined boxes even with no CSS border.

## Fix
- **Inverse CTAs:** text-only on dark surfaces (no translucent fill plate)
- **Header icons:** no hover plate / chrome — icon + color shift only
- **Primary CTA:** dark inset shadow to kill light anti-alias fringe on rounded copper buttons
- **Footer social:** remove light fill squares

## Verification
- Inspected live CSS on `wadesplumbingandseptic-com.vercel.app` to confirm borders were already `0`
- `npm run check` passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

