### PR TITLE
Polish global search for mobile

### DIFF
--- a/components/global-search.tsx
+++ b/components/global-search.tsx
@@ -13,10 +13,12 @@ import {
 	Search,
 	Sparkles,
 	Wrench,
+	X,
 } from "lucide-react"
 
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogDescription,
 	DialogHeader,
@@ -52,7 +54,7 @@ const TYPE_BADGE: Record<
 		className: "bg-accent text-accent-foreground",
 	},
 	tip: {
-		label: "Expert Tip",
+		label: "Tip",
 		className: "bg-secondary text-secondary-foreground",
 	},
 	page: {
@@ -100,13 +102,14 @@ function ResultRow({
 			onMouseEnter={onHover}
 			onClick={onSelect}
 			className={cn(
-				"grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 rounded-md px-3 py-3 text-left transition-colors",
+				"grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:gap-4 sm:rounded-md sm:px-3 sm:py-3",
+				"active:bg-muted min-h-16 sm:min-h-0",
 				active ? "bg-muted" : "hover:bg-muted/70",
 			)}
 		>
 			<div
 				className={cn(
-					"relative flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-md",
+					"relative flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-md sm:size-14",
 					hit.image ? "bg-muted" : "bg-accent text-primary",
 				)}
 			>
@@ -124,10 +127,10 @@ function ResultRow({
 			</div>
 
 			<div className="min-w-0">
-				<div className="flex flex-wrap items-center gap-2">
+				<div className="flex min-w-0 items-center gap-2">
 					<span
 						className={cn(
-							"rounded-sm px-1.5 py-0.5 text-[0.68rem] font-extrabold tracking-[0.14em] uppercase",
+							"shrink-0 rounded-sm px-1.5 py-0.5 text-[0.65rem] font-extrabold tracking-[0.12em] uppercase sm:text-[0.68rem] sm:tracking-[0.14em]",
 							badge.className,
 						)}
 					>
@@ -139,10 +142,10 @@ function ResultRow({
 						</span>
 					) : null}
 				</div>
-				<p className="text-foreground mt-1 truncate text-[1.05rem] font-extrabold tracking-[-0.02em]">
+				<p className="text-foreground mt-1 truncate text-base font-extrabold tracking-[-0.02em] sm:text-[1.05rem]">
 					{hit.title}
 				</p>
-				<p className="text-muted-foreground mt-0.5 line-clamp-2 text-sm leading-snug">
+				<p className="text-muted-foreground mt-0.5 line-clamp-1 text-sm leading-snug sm:line-clamp-2">
 					{hit.description}
 				</p>
 			</div>
@@ -265,28 +268,45 @@ export function GlobalSearch({
 	return (
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent
-				showCloseButton
+				showCloseButton={false}
 				className={cn(
-					"bg-background text-foreground top-[max(1.25rem,8vh)] max-h-[min(88vh,52rem)] w-[min(96vw,48rem)] max-w-none translate-y-0 gap-0 overflow-hidden rounded-xl border-0 p-0 shadow-[0_28px_80px_rgba(16,18,20,0.32)] sm:max-w-none",
+					"bg-background text-foreground z-50 flex max-w-none flex-col gap-0 overflow-hidden border-0 p-0 shadow-[0_28px_80px_rgba(16,18,20,0.32)]",
+					// Mobile: full-viewport sheet that keeps the input pinned
+					"inset-0 top-0 left-0 h-[100dvh] max-h-[100dvh] w-full translate-x-0 translate-y-0 rounded-none",
+					// Desktop: large floating palette
+					"sm:inset-auto sm:top-[max(1.25rem,8vh)] sm:left-[50%] sm:h-auto sm:max-h-[min(88vh,52rem)] sm:w-[min(96vw,48rem)] sm:translate-x-[-50%] sm:translate-y-0 sm:rounded-xl",
 					"data-[state=open]:animate-rise",
 				)}
-				overlayClassName="bg-ink/55 backdrop-blur-md supports-backdrop-filter:bg-ink/40"
+				overlayClassName="bg-ink/60 backdrop-blur-md supports-backdrop-filter:bg-ink/45"
 			>
-				<DialogHeader className="border-border border-b px-5 pt-5 pb-4 sm:px-7 sm:pt-6">
-					<DialogTitle className="text-2xl font-extrabold tracking-[-0.03em] sm:text-[1.85rem]">
-						Search Wade&apos;s
-					</DialogTitle>
-					<DialogDescription className="text-muted-foreground text-sm sm:text-base">
-						Find plumbing &amp; septic services, expert tips, and pages across
-						the Central Coast.
-					</DialogDescription>
+				<DialogHeader className="border-border shrink-0 border-b px-4 pt-[max(0.85rem,env(safe-area-inset-top))] pr-14 pb-3 sm:px-7 sm:pt-6 sm:pr-7 sm:pb-4">
+					<div className="flex items-start justify-between gap-3">
+						<div className="min-w-0">
+							<DialogTitle className="text-xl font-extrabold tracking-[-0.03em] sm:text-[1.85rem]">
+								Search Wade&apos;s
+							</DialogTitle>
+							<DialogDescription className="text-muted-foreground mt-1 text-sm sm:mt-1.5 sm:text-base">
+								<span className="sm:hidden">
+									Services, tips, and pages on the Central Coast.
+								</span>
+								<span className="hidden sm:inline">
+									Find plumbing &amp; septic services, expert tips, and pages
+									across the Central Coast.
+								</span>
+							</DialogDescription>
+						</div>
+					</div>
+					<DialogClose className="focus-visible:ring-ring text-foreground/70 hover:bg-muted hover:text-foreground absolute top-[max(0.65rem,env(safe-area-inset-top))] right-3 flex size-11 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none sm:top-4 sm:right-4 sm:size-9">
+						<X className="size-5 sm:size-4" />
+						<span className="sr-only">Close</span>
+					</DialogClose>
 				</DialogHeader>
 
-				<div className="border-border border-b px-5 py-4 sm:px-7">
+				<div className="border-border shrink-0 border-b px-4 py-3 sm:px-7 sm:py-4">
 					<label className="relative block">
 						<span className="sr-only">Search services and tips</span>
 						<Search
-							className="text-primary pointer-events-none absolute top-1/2 left-4 size-5 -translate-y-1/2"
+							className="text-primary pointer-events-none absolute top-1/2 left-3.5 size-5 -translate-y-1/2 sm:left-4"
 							aria-hidden
 						/>
 						<input
@@ -297,10 +317,11 @@ export function GlobalSearch({
 								setActiveIndex(0)
 							}}
 							onKeyDown={onKeyDown}
-							placeholder="Try “clogged drain”, “septic pumping”, or “water heater”…"
+							placeholder="Search services or tips…"
 							autoComplete="off"
 							autoCorrect="off"
 							spellCheck={false}
+							enterKeyHint="search"
 							role="combobox"
 							aria-expanded
 							aria-controls="global-search-results"
@@ -309,19 +330,42 @@ export function GlobalSearch({
 									? `search-option-${flatHits[safeActiveIndex].id}`
 									: undefined
 							}
-							className="border-border bg-card text-foreground placeholder:text-muted-foreground focus-visible:border-primary focus-visible:ring-primary/25 h-14 w-full rounded-lg border pr-4 pl-12 text-base outline-none focus-visible:ring-2 sm:h-16 sm:text-lg"
+							className="border-border bg-card text-foreground placeholder:text-muted-foreground focus-visible:border-primary focus-visible:ring-primary/25 h-14 w-full rounded-lg border pr-4 pl-11 text-base outline-none focus-visible:ring-2 sm:h-16 sm:pl-12 sm:text-lg"
 						/>
 					</label>
-					<p className="text-muted-foreground mt-2.5 text-xs sm:text-sm">
+					<p className="text-muted-foreground mt-2 hidden text-sm sm:mt-2.5 sm:block">
 						Smart matching understands synonyms like toilet ↔ clog and septic ↔
 						pumping. Use ↑ ↓ and Enter.
 					</p>
+					{!query.trim() ? (
+						<div className="mt-2.5 flex [scrollbar-width:none] gap-2 overflow-x-auto pb-0.5 [-ms-overflow-style:none] sm:hidden [&::-webkit-scrollbar]:hidden">
+							{[
+								"clogged drain",
+								"septic pumping",
+								"water heater",
+								"toilet",
+							].map((suggestion) => (
+								<button
+									key={suggestion}
+									type="button"
+									onClick={() => {
+										setQuery(suggestion)
+										setActiveIndex(0)
+										inputRef.current?.focus()
+									}}
+									className="border-border bg-card text-foreground shrink-0 rounded-md border px-3 py-1.5 text-xs font-extrabold tracking-[-0.01em]"
+								>
+									{suggestion}
+								</button>
+							))}
+						</div>
+					) : null}
 				</div>
 
 				<div
 					id="global-search-results"
 					role="listbox"
-					className="max-h-[min(52vh,28rem)] overflow-y-auto px-2 py-3 sm:px-3"
+					className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-2 sm:max-h-[min(52vh,28rem)] sm:flex-none sm:px-3 sm:py-3"
 				>
 					{loading ? (
 						<div className="text-muted-foreground flex items-center justify-center gap-2 px-4 py-12 text-sm">
@@ -338,7 +382,7 @@ export function GlobalSearch({
 
 					{showEmpty ? (
 						<div className="px-4 py-10 text-center">
-							<p className="text-foreground text-xl font-extrabold tracking-[-0.02em]">
+							<p className="text-foreground text-lg font-extrabold tracking-[-0.02em] sm:text-xl">
 								No matches for “{query.trim()}”
 							</p>
 							<p className="text-muted-foreground mt-2 text-sm">
@@ -348,9 +392,9 @@ export function GlobalSearch({
 					) : null}
 
 					{!loading && !error && flatHits.length > 0 ? (
-						<div className="space-y-5">
+						<div className="space-y-4 sm:space-y-5">
 							{showPopular ? (
-								<p className="text-muted-foreground px-3 text-xs font-extrabold tracking-[0.16em] uppercase">
+								<p className="text-muted-foreground px-2.5 text-[0.7rem] font-extrabold tracking-[0.16em] uppercase sm:px-3 sm:text-xs">
 									Popular right now
 								</p>
 							) : null}
@@ -363,9 +407,9 @@ export function GlobalSearch({
 								return (
 									<section key={key} aria-label={meta.label}>
 										{!showPopular ? (
-											<div className="mb-1.5 flex items-center gap-2 px-3">
+											<div className="mb-1 flex items-center gap-2 px-2.5 sm:mb-1.5 sm:px-3">
 												<Icon className="text-primary size-3.5" aria-hidden />
-												<h3 className="text-muted-foreground text-xs font-extrabold tracking-[0.16em] uppercase">
+												<h3 className="text-muted-foreground text-[0.7rem] font-extrabold tracking-[0.16em] uppercase sm:text-xs">
 													{meta.label}
 												</h3>
 											</div>
@@ -394,12 +438,13 @@ export function GlobalSearch({
 					) : null}
 				</div>
 
-				<div className="border-border bg-muted/50 text-muted-foreground flex flex-wrap items-center justify-between gap-2 border-t px-5 py-3 text-xs sm:px-7">
+				<div className="border-border bg-muted/50 text-muted-foreground flex shrink-0 flex-wrap items-center justify-between gap-2 border-t px-4 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] text-xs sm:px-7 sm:pb-3">
 					<span>
 						{flatHits.length
 							? `${flatHits.length} result${flatHits.length === 1 ? "" : "s"}`
 							: "Services · Tips · Pages"}
 					</span>
+					<span className="sm:hidden">Tap a result to open</span>
 					<span className="hidden sm:inline">
 						<kbd className="border-border bg-card rounded-sm border px-1.5 py-0.5 font-sans">
 							Esc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Makes the global search feel native on phones: full-viewport sheet, pinned input, denser rich results, and shorter mobile copy.

## Changes
- Full-screen search sheet on mobile (`100dvh`) with safe-area padding
- Larger close tap target; search input stays pinned while results scroll
- Compact result rows (smaller thumbnails, one-line descriptions on small screens)
- Shorter mobile placeholder/description; hide keyboard shortcut chrome
- Quick suggestion chips when the query is empty on mobile

## Test plan
- [ ] Open search from the header icon on a phone-width viewport
- [ ] Confirm full-screen sheet, easy-to-hit close, and pinned input with keyboard open
- [ ] Tap a suggestion chip and verify results update
- [ ] Confirm result rows are easy to scan/tap
- [ ] Desktop palette still looks large and centered with blur
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

