### PR TITLE
Make global search smarter with intent-aware ranking

### DIFF
--- a/components/global-search.tsx
+++ b/components/global-search.tsx
@@ -27,7 +27,9 @@ import {
 import { cn } from "@/lib/utils"
 import {
 	groupSearchHits,
+	highlightMatches,
 	searchDocuments,
+	suggestSearches,
 	type SearchDocument,
 	type SearchHit,
 	type SearchResultType,
@@ -54,7 +56,7 @@ const TYPE_BADGE: Record<
 		className: "bg-accent text-accent-foreground",
 	},
 	tip: {
-		label: "Tip",
+		label: "Expert Tip",
 		className: "bg-secondary text-secondary-foreground",
 	},
 	page: {
@@ -80,13 +82,38 @@ function ResultIcon({ doc }: { doc: SearchDocument }) {
 	return <FileText className="size-5" aria-hidden />
 }
 
+function HighlightedTitle({ title, query }: { title: string; query: string }) {
+	const parts = query.trim()
+		? highlightMatches(title, query)
+		: [{ text: title, match: false }]
+
+	return (
+		<span className="truncate">
+			{parts.map((part, index) =>
+				part.match ? (
+					<mark
+						key={`${part.text}-${index}`}
+						className="bg-accent text-accent-foreground rounded-sm px-0.5"
+					>
+						{part.text}
+					</mark>
+				) : (
+					<span key={`${part.text}-${index}`}>{part.text}</span>
+				),
+			)}
+		</span>
+	)
+}
+
 function ResultRow({
 	hit,
+	query,
 	active,
 	onHover,
 	onSelect,
 }: {
 	hit: SearchHit
+	query: string
 	active: boolean
 	onHover: () => void
 	onSelect: () => void
@@ -141,9 +168,14 @@ function ResultRow({
 							{hit.category}
 						</span>
 					) : null}
+					{query.trim() && hit.matchLabel !== "Popular" ? (
+						<span className="text-muted-foreground hidden truncate text-xs sm:inline">
+							· {hit.matchLabel}
+						</span>
+					) : null}
 				</div>
 				<p className="text-foreground mt-1 truncate text-base font-extrabold tracking-[-0.02em] sm:text-[1.05rem]">
-					{hit.title}
+					<HighlightedTitle title={hit.title} query={query} />
 				</p>
 				<p className="text-muted-foreground mt-0.5 line-clamp-1 text-sm leading-snug sm:line-clamp-2">
 					{hit.description}
@@ -214,6 +246,8 @@ export function GlobalSearch({
 		if (!index) return [] as SearchHit[]
 		return searchDocuments(index, query, query.trim() ? 24 : 8)
 	}, [index, query])
+
+	const suggestions = React.useMemo(() => suggestSearches(query, 6), [query])
 
 	const grouped = React.useMemo(() => groupSearchHits(hits), [hits])
 
@@ -334,17 +368,12 @@ export function GlobalSearch({
 						/>
 					</label>
 					<p className="text-muted-foreground mt-2 hidden text-sm sm:mt-2.5 sm:block">
-						Smart matching understands synonyms like toilet ↔ clog and septic ↔
-						pumping. Use ↑ ↓ and Enter.
+						Understands symptoms, synonyms, and intent — try “no hot water”,
+						“sewage smell”, or “quote”. Use ↑ ↓ and Enter.
 					</p>
-					{!query.trim() ? (
-						<div className="mt-2.5 flex [scrollbar-width:none] gap-2 overflow-x-auto pb-0.5 [-ms-overflow-style:none] sm:hidden [&::-webkit-scrollbar]:hidden">
-							{[
-								"clogged drain",
-								"septic pumping",
-								"water heater",
-								"toilet",
-							].map((suggestion) => (
+					{suggestions.length ? (
+						<div className="mt-2.5 flex [scrollbar-width:none] gap-2 overflow-x-auto pb-0.5 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+							{suggestions.map((suggestion) => (
 								<button
 									key={suggestion}
 									type="button"
@@ -353,7 +382,7 @@ export function GlobalSearch({
 										setActiveIndex(0)
 										inputRef.current?.focus()
 									}}
-									className="border-border bg-card text-foreground shrink-0 rounded-md border px-3 py-1.5 text-xs font-extrabold tracking-[-0.01em]"
+									className="border-border bg-card text-foreground hover:border-primary/40 shrink-0 rounded-md border px-3 py-1.5 text-xs font-extrabold tracking-[-0.01em]"
 								>
 									{suggestion}
 								</button>
@@ -386,8 +415,26 @@ export function GlobalSearch({
 								No matches for “{query.trim()}”
 							</p>
 							<p className="text-muted-foreground mt-2 text-sm">
-								Try a service name, symptom, city, or tip topic.
+								Try a symptom (“slow drain”), city, or service name.
 							</p>
+							{suggestions.length ? (
+								<div className="mt-4 flex flex-wrap justify-center gap-2">
+									{suggestions.slice(0, 4).map((suggestion) => (
+										<button
+											key={suggestion}
+											type="button"
+											onClick={() => {
+												setQuery(suggestion)
+												setActiveIndex(0)
+												inputRef.current?.focus()
+											}}
+											className="border-border bg-card text-foreground rounded-md border px-3 py-1.5 text-xs font-extrabold"
+										>
+											Try “{suggestion}”
+										</button>
+									))}
+								</div>
+							) : null}
 						</div>
 					) : null}
 
@@ -423,6 +470,7 @@ export function GlobalSearch({
 													<li key={hit.id}>
 														<ResultRow
 															hit={hit}
+															query={query}
 															active={flatIndex === safeActiveIndex}
 															onHover={() => setActiveIndex(flatIndex)}
 															onSelect={() => runHit(hit)}

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -4,7 +4,7 @@ import { cacheLife, cacheTag } from "next/cache"
 
 import { getCollection } from "@/lib/content"
 import { getServiceImage } from "@/lib/service-images"
-import type { SearchDocument } from "@/lib/search"
+import type { SearchDocument, SearchIntent } from "@/lib/search"
 import {
 	companyNavigation,
 	primaryNavigation,
@@ -12,7 +12,28 @@ import {
 	siteConfig,
 } from "@/lib/site"
 
-function keywordsFromText(...parts: Array<string | undefined>) {
+const SERVICE_POPULARITY: Record<string, number> = {
+	"drain-cleaning": 48,
+	"septic-tank-cleaning-and-pumping": 47,
+	"hydro-jetting": 45,
+	"leak-detection": 44,
+	"sewer-camera-inspection": 43,
+	"tankless-water-heater-installation": 42,
+	"water-heater-installation": 41,
+	"toilet-repair": 40,
+	"garbage-disposal-installation": 38,
+	"septic-tank-inspection-and-assessment": 37,
+	"trenchless-sewer-line-replacement": 36,
+	"backflow-prevention-testing": 34,
+}
+
+const CATEGORY_INTENTS: Record<string, SearchIntent[]> = {
+	Plumbing: ["service"],
+	Septic: ["service"],
+	Commercial: ["service"],
+}
+
+function keywordsFromText(...parts: Array<string | undefined | null>) {
 	const values = parts
 		.filter(Boolean)
 		.join(" ")
@@ -22,6 +43,55 @@ function keywordsFromText(...parts: Array<string | undefined>) {
 		.filter((token) => token.length > 2)
 
 	return [...new Set(values)]
+}
+
+function stripMarkdown(value: string) {
+	return value
+		.replace(/```[\s\S]*?```/g, " ")
+		.replace(/`[^`]*`/g, " ")
+		.replace(/!\[[^\]]*]\([^)]*\)/g, " ")
+		.replace(/\[[^\]]*]\([^)]*\)/g, " ")
+		.replace(/^#{1,6}\s+/gm, " ")
+		.replace(/[*_>~-]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+}
+
+function bodyExcerpt(content: string, maxChars = 480) {
+	const cleaned = stripMarkdown(content)
+	if (cleaned.length <= maxChars) return cleaned
+	return cleaned.slice(0, maxChars)
+}
+
+function cityFromAreaSlug(slug: string) {
+	const leaf = slug.split("/").pop() ?? slug
+	return leaf
+		.replace(/-ca-plumbing-septic-services$/i, "")
+		.replace(/-/g, " ")
+		.trim()
+}
+
+function serviceBoostKeywords(title: string, category?: string) {
+	const haystack = `${title} ${category ?? ""}`.toLowerCase()
+	const extras: string[] = []
+
+	if (haystack.includes("drain"))
+		extras.push("clog", "clogged", "backup", "slow")
+	if (haystack.includes("septic"))
+		extras.push("tank", "pumping", "leach", "odor")
+	if (haystack.includes("heater"))
+		extras.push("hot water", "tankless", "no hot water")
+	if (haystack.includes("leak")) extras.push("drip", "burst", "slab")
+	if (haystack.includes("toilet")) extras.push("flush", "running", "commode")
+	if (haystack.includes("camera") || haystack.includes("inspection")) {
+		extras.push("video", "diagnose", "locate")
+	}
+	if (haystack.includes("jetting")) extras.push("hydro", "pressure", "roots")
+	if (haystack.includes("grease"))
+		extras.push("restaurant", "commercial", "interceptor")
+	if (haystack.includes("backflow")) extras.push("testing", "rpz", "prevention")
+
+	return extras
 }
 
 export async function getSearchIndex(): Promise<SearchDocument[]> {
@@ -35,41 +105,64 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 		getCollection("pages"),
 	])
 
-	const serviceDocs: SearchDocument[] = services.map((service, index) => ({
-		id: `service:${service.slug}`,
-		type: "service",
-		title: service.title,
-		description: service.description,
-		href: `/service-offerings/${service.slug}`,
-		category: service.category ?? "Service",
-		image: getServiceImage(service.category, service.image),
-		keywords: keywordsFromText(
-			service.title,
-			service.description,
-			service.category,
-			service.slug.replaceAll("-", " "),
-			...(service.tags ?? []),
-		),
-		popularity: Math.max(1, 40 - index),
-	}))
+	const serviceDocs: SearchDocument[] = services.map((service, index) => {
+		const boost = SERVICE_POPULARITY[service.slug] ?? Math.max(1, 34 - index)
+		const featuredBoost = service.featured ? 8 : 0
+		const orderBoost =
+			service.order !== undefined
+				? Math.max(0, 12 - Math.floor(service.order / 5))
+				: 0
 
-	const tipDocs: SearchDocument[] = posts.map((post, index) => ({
-		id: `tip:${post.slug}`,
-		type: "tip",
-		title: post.title,
-		description: post.description,
-		href: `/${post.slug}`,
-		category: post.category ?? "Expert Tip",
-		image: post.image ?? "/images/team/byron-working.webp",
-		keywords: keywordsFromText(
-			post.title,
-			post.description,
-			post.category,
-			post.slug.replaceAll("-", " "),
-			...(post.tags ?? []),
-		),
-		popularity: Math.max(1, 30 - index),
-	}))
+		return {
+			id: `service:${service.slug}`,
+			type: "service",
+			title: service.title,
+			description: service.description,
+			href: `/service-offerings/${service.slug}`,
+			category: service.category ?? "Service",
+			image: getServiceImage(service.category, service.image),
+			keywords: keywordsFromText(
+				service.title,
+				service.description,
+				service.category,
+				service.slug.replaceAll("-", " "),
+				...(service.tags ?? []),
+				...serviceBoostKeywords(service.title, service.category),
+			),
+			body: bodyExcerpt(service.content),
+			popularity: boost + featuredBoost + orderBoost,
+			intents: CATEGORY_INTENTS[service.category ?? ""] ?? ["service"],
+		}
+	})
+
+	const tipDocs: SearchDocument[] = posts.map((post, index) => {
+		// Prefer tagged / categorized guides slightly without using Date.now()
+		// (keeps the cached index deterministic).
+		const topicBoost = (post.tags?.length ?? 0) > 0 ? 3 : 0
+
+		return {
+			id: `tip:${post.slug}`,
+			type: "tip",
+			title: post.title,
+			description: post.description,
+			href: `/${post.slug}`,
+			category: post.category ?? "Expert Tip",
+			image: post.image ?? "/images/team/byron-working.webp",
+			keywords: keywordsFromText(
+				post.title,
+				post.description,
+				post.category,
+				post.slug.replaceAll("-", " "),
+				...(post.tags ?? []),
+				"guide",
+				"tips",
+				"how to",
+			),
+			body: bodyExcerpt(post.content, 560),
+			popularity: Math.max(1, 28 - index) + topicBoost,
+			intents: ["tip"],
+		}
+	})
 
 	const pageAllowlist = new Set([
 		"about-us",
@@ -90,22 +183,89 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 			(page) =>
 				pageAllowlist.has(page.slug) || page.slug.startsWith("service-area/"),
 		)
-		.map((page, index) => ({
-			id: `page:${page.slug}`,
-			type: "page" as const,
-			title: page.title,
-			description: page.description,
-			href: `/${page.slug}`,
-			category: page.eyebrow ?? "Page",
-			image: page.image,
+		.map((page, index) => {
+			const isArea = page.slug.startsWith("service-area/")
+			const city = isArea ? cityFromAreaSlug(page.slug) : ""
+
+			return {
+				id: `page:${page.slug}`,
+				type: "page" as const,
+				title: page.title,
+				description: page.description,
+				href: `/${page.slug}`,
+				category: isArea ? "Service Area" : (page.eyebrow ?? "Page"),
+				image: page.image,
+				keywords: keywordsFromText(
+					page.title,
+					page.description,
+					page.eyebrow,
+					page.slug.replaceAll("-", " ").replaceAll("/", " "),
+					city,
+					isArea ? "near me service area city" : "",
+				),
+				body: bodyExcerpt(page.content, 320),
+				popularity: isArea ? 12 : pageAllowlist.has(page.slug) ? 22 - index : 5,
+				intents: isArea
+					? (["area", "service"] as SearchIntent[])
+					: page.slug === "contact"
+						? (["quote", "call"] as SearchIntent[])
+						: (["browse"] as SearchIntent[]),
+			}
+		})
+
+	const categoryDocs: SearchDocument[] = [
+		{
+			id: "category:plumbing",
+			type: "page",
+			title: "Plumbing Services",
+			description: "Browse residential and commercial plumbing services.",
+			href: "/service-category/plumbing",
+			category: "Category",
 			keywords: keywordsFromText(
-				page.title,
-				page.description,
-				page.eyebrow,
-				page.slug.replaceAll("-", " ").replaceAll("/", " "),
+				"plumbing",
+				"drains",
+				"pipes",
+				"fixtures",
+				"water heater",
 			),
-			popularity: pageAllowlist.has(page.slug) ? 20 - index : 5,
-		}))
+			popularity: 32,
+			intents: ["service", "browse"],
+		},
+		{
+			id: "category:septic",
+			type: "page",
+			title: "Septic Services",
+			description:
+				"Pumping, inspections, repairs, and engineered septic systems.",
+			href: "/service-category/septic",
+			category: "Category",
+			keywords: keywordsFromText(
+				"septic",
+				"tank",
+				"pumping",
+				"leach field",
+				"drainfield",
+			),
+			popularity: 31,
+			intents: ["service", "browse"],
+		},
+		{
+			id: "category:commercial",
+			type: "page",
+			title: "Commercial Plumbing",
+			description: "Grease traps, backflow, and commercial maintenance.",
+			href: "/service-category/commercial",
+			category: "Category",
+			keywords: keywordsFromText(
+				"commercial",
+				"restaurant",
+				"grease trap",
+				"business",
+			),
+			popularity: 26,
+			intents: ["service", "browse"],
+		},
+	]
 
 	const navDocs: SearchDocument[] = [
 		...primaryNavigation,
@@ -119,7 +279,8 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 		href: item.href,
 		category: "Navigation",
 		keywords: keywordsFromText(item.label, item.href.replaceAll("/", " ")),
-		popularity: 18 - index,
+		popularity: 16 - index,
+		intents: ["browse"] as SearchIntent[],
 	}))
 
 	const actionDocs: SearchDocument[] = [
@@ -136,9 +297,11 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 				"phone",
 				"schedule",
 				"book",
+				"appointment",
 				siteConfig.phone,
 			),
-			popularity: 50,
+			popularity: 55,
+			intents: ["call"],
 		},
 		{
 			id: "action:contact",
@@ -153,8 +316,10 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 				"contact",
 				"message",
 				"price",
+				"cost",
 			),
-			popularity: 45,
+			popularity: 50,
+			intents: ["quote"],
 		},
 		{
 			id: "action:services",
@@ -164,7 +329,8 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 			href: "/services",
 			category: "Action",
 			keywords: keywordsFromText("services", "menu", "plumbing", "septic"),
-			popularity: 42,
+			popularity: 44,
+			intents: ["browse", "service"],
 		},
 		{
 			id: "action:tips",
@@ -179,20 +345,41 @@ export async function getSearchIndex(): Promise<SearchDocument[]> {
 				"guides",
 				"advice",
 				"articles",
+				"how to",
+				"diy",
+			),
+			popularity: 42,
+			intents: ["tip", "browse"],
+		},
+		{
+			id: "action:areas",
+			type: "action",
+			title: "View service areas",
+			description: "See the Central Coast and Georgia communities we serve.",
+			href: "/service-areas",
+			category: "Action",
+			keywords: keywordsFromText(
+				"service areas",
+				"near me",
+				"santa cruz",
+				"coverage",
 			),
 			popularity: 40,
+			intents: ["area", "browse"],
 		},
 	]
 
 	const deduped = new Map<string, SearchDocument>()
 	for (const document of [
 		...actionDocs,
+		...categoryDocs,
 		...serviceDocs,
 		...tipDocs,
 		...pageDocs,
 		...navDocs,
 	]) {
-		if (!deduped.has(document.href)) {
+		const existing = deduped.get(document.href)
+		if (!existing || (document.popularity ?? 0) > (existing.popularity ?? 0)) {
 			deduped.set(document.href, document)
 		}
 	}

--- a/lib/search.ts
+++ b/lib/search.ts
@@ -1,5 +1,8 @@
 export type SearchResultType = "service" | "tip" | "page" | "action"
 
+export type SearchIntent =
+	"browse" | "service" | "tip" | "call" | "quote" | "area"
+
 export type SearchDocument = {
 	id: string
 	type: SearchResultType
@@ -9,12 +12,16 @@ export type SearchDocument = {
 	category?: string
 	image?: string
 	keywords: string[]
+	/** Extra body/excerpt terms — weighted lower than keywords. */
+	body?: string
 	popularity?: number
+	intents?: SearchIntent[]
 }
 
 export type SearchHit = SearchDocument & {
 	score: number
-	matchedOn: "title" | "category" | "keyword" | "description"
+	matchedOn: "title" | "category" | "keyword" | "description" | "body"
+	matchLabel: string
 }
 
 /** Domain synonyms so casual homeowner language finds the right pages. */
@@ -25,12 +32,18 @@ export const SEARCH_SYNONYMS: Record<string, string[]> = {
 		"drainfield",
 		"drain field",
 		"atu",
-		"ats",
 		"engineered septic",
 		"septic pumping",
-		"septic pump",
+		"septic system",
 	],
-	clog: ["clogged", "backup", "blockage", "slow drain", "stopped up"],
+	clog: [
+		"clogged",
+		"backup",
+		"blockage",
+		"slow drain",
+		"stopped up",
+		"plugged",
+	],
 	drain: ["drains", "sewer", "cleanout", "hydro jetting", "jetting"],
 	"water heater": [
 		"tankless",
@@ -38,9 +51,10 @@ export const SEARCH_SYNONYMS: Record<string, string[]> = {
 		"tankless water heater",
 		"boiler",
 		"water heaters",
+		"no hot water",
 	],
-	leak: ["drip", "burst pipe", "slab leak", "leak detection"],
-	toilet: ["toilets", "commode", "wax ring", "running toilet"],
+	leak: ["drip", "burst pipe", "slab leak", "leak detection", "leaking"],
+	toilet: ["toilets", "commode", "wax ring", "running toilet", "flush"],
 	sink: ["faucet", "garbage disposal", "disposal", "kitchen sink"],
 	urgent: ["emergency", "priority", "same day", "overflow", "flooding"],
 	inspection: ["camera inspection", "video inspection", "assessment"],
@@ -49,8 +63,15 @@ export const SEARCH_SYNONYMS: Record<string, string[]> = {
 	commercial: ["business", "restaurant", "grease trap", "multi-unit"],
 	backflow: ["backflow prevention", "backflow testing", "rpz"],
 	pipe: ["repipe", "pipe replacement", "pipe repair", "trenchless"],
-	camera: ["video inspection", "sewer camera", "locate"],
-	"santa cruz": ["scotts valley", "watsonville", "aptos", "capitola"],
+	camera: ["video inspection", "sewer camera", "locate line"],
+	"santa cruz": [
+		"scotts valley",
+		"watsonville",
+		"aptos",
+		"capitola",
+		"soquel",
+		"felton",
+	],
 	garbage: ["disposal", "garbage disposal", "sink disposal"],
 	faucet: ["tap", "spigot", "kitchen faucet", "bathroom faucet"],
 	sump: ["sump pump", "basement pump"],
@@ -58,7 +79,67 @@ export const SEARCH_SYNONYMS: Record<string, string[]> = {
 	root: ["rooter", "tree roots", "sewer roots"],
 	slab: ["slab leak", "under slab"],
 	tankless: ["tankless water heater", "on demand", "instant hot water"],
+	odor: ["smell", "sewage smell", "rotten egg", "sulfur"],
+	"low pressure": ["weak pressure", "low water pressure", "no pressure"],
+	shower: ["shower valve", "shower head", "shower drain"],
+	water: ["potable", "drinking water", "water line"],
 }
+
+/**
+ * Symptom / intent phrases mapped onto search terms.
+ * These fire only on phrase presence in the query.
+ */
+export const INTENT_PHRASES: Array<{
+	phrases: string[]
+	expand: string[]
+	intent: SearchIntent
+}> = [
+	{
+		phrases: ["no hot water", "cold water only", "water not hot"],
+		expand: ["water heater", "tankless", "hot water"],
+		intent: "service",
+	},
+	{
+		phrases: ["sewage smell", "smells like sewage", "rotten egg smell"],
+		expand: ["odor", "septic", "drain", "vent"],
+		intent: "service",
+	},
+	{
+		phrases: ["slow drain", "drains slow", "water backing up", "backup"],
+		expand: ["clog", "drain", "sewer", "septic"],
+		intent: "service",
+	},
+	{
+		phrases: ["gurgling", "bubbling toilet", "toilet bubbles"],
+		expand: ["drain", "sewer", "vent", "clog"],
+		intent: "service",
+	},
+	{
+		phrases: ["yellow water", "brown water", "rusty water", "hard water"],
+		expand: ["water", "softener", "filtration", "heater"],
+		intent: "service",
+	},
+	{
+		phrases: ["how to", "diy", "guide", "tips", "what causes", "why is"],
+		expand: ["tips", "guide", "maintenance"],
+		intent: "tip",
+	},
+	{
+		phrases: ["cost", "price", "how much", "estimate", "quote"],
+		expand: ["quote", "estimate", "contact"],
+		intent: "quote",
+	},
+	{
+		phrases: ["call", "phone", "schedule", "book appointment"],
+		expand: ["call", "phone", "schedule"],
+		intent: "call",
+	},
+	{
+		phrases: ["near me", "service area", "do you serve", "in my area"],
+		expand: ["service areas", "santa cruz", "area"],
+		intent: "area",
+	},
+]
 
 const STOP_WORDS = new Set([
 	"a",
@@ -82,7 +163,25 @@ const STOP_WORDS = new Set([
 	"do",
 	"i",
 	"we",
+	"can",
+	"you",
+	"me",
+	"it",
+	"this",
+	"that",
+	"from",
+	"get",
+	"need",
+	"help",
 ])
+
+const MATCH_LABELS: Record<SearchHit["matchedOn"], string> = {
+	title: "Title match",
+	category: "Category match",
+	keyword: "Related topic",
+	description: "Description match",
+	body: "In article",
+}
 
 function normalize(value: string) {
 	return value
@@ -105,12 +204,25 @@ function familyTerms(canonical: string, aliases: string[]) {
 	return [canonical, ...aliases].map(normalize)
 }
 
+function lightStem(token: string) {
+	if (token.length < 5) return token
+	if (token.endsWith("ies") && token.length > 5) return `${token.slice(0, -3)}y`
+	if (token.endsWith("ing") && token.length > 6) return token.slice(0, -3)
+	if (token.endsWith("ers") && token.length > 5) return token.slice(0, -1)
+	if (token.endsWith("ed") && token.length > 5) return token.slice(0, -2)
+	if (token.endsWith("es") && token.length > 5) return token.slice(0, -2)
+	if (token.endsWith("s") && !token.endsWith("ss")) return token.slice(0, -1)
+	return token
+}
+
 function tokenMatchesTerm(token: string, term: string) {
 	if (token === term) return true
 	if (token.length < 3) return false
 
-	// Light plural/stem tolerance without substring false positives
-	// (e.g. "drain" must not match "drainfield").
+	const stemToken = lightStem(token)
+	const stemTerm = lightStem(term)
+	if (stemToken === stemTerm) return true
+
 	if (token === `${term}s` || term === `${token}s`) return true
 	if (token.endsWith("ed") && token.slice(0, -2) === term) return true
 	if (term.endsWith("ed") && term.slice(0, -2) === token) return true
@@ -120,16 +232,48 @@ function tokenMatchesTerm(token: string, term: string) {
 	return false
 }
 
+function ngrams(tokens: string[], size: number) {
+	if (tokens.length < size) return [] as string[]
+	const grams: string[] = []
+	for (let i = 0; i <= tokens.length - size; i += 1) {
+		grams.push(tokens.slice(i, i + size).join(" "))
+	}
+	return grams
+}
+
+export type ParsedQuery = {
+	raw: string
+	tokens: string[]
+	phrase: string
+	expanded: string[]
+	original: Set<string>
+	bigrams: string[]
+	intents: Set<SearchIntent>
+	prefix: string | null
+}
+
 /**
- * Expand query tokens with synonyms.
+ * Expand query tokens with synonyms + intent phrases.
  * Uses exact/phrase matching — never bare substring includes — so "drain"
  * does not activate the septic "drainfield" family.
  */
-export function expandQuery(query: string) {
+export function expandQuery(query: string): ParsedQuery {
 	const tokens = tokenize(query)
 	const phrase = normalize(query)
 	const expanded = new Set(tokens)
 	const original = new Set(tokens)
+	const intents = new Set<SearchIntent>()
+
+	for (const rule of INTENT_PHRASES) {
+		if (rule.phrases.some((item) => phrase.includes(normalize(item)))) {
+			intents.add(rule.intent)
+			for (const term of rule.expand) {
+				for (const part of normalize(term).split(" ")) {
+					if (part.length > 2 && !STOP_WORDS.has(part)) expanded.add(part)
+				}
+			}
+		}
+	}
 
 	for (const [canonical, aliases] of Object.entries(SEARCH_SYNONYMS)) {
 		const family = familyTerms(canonical, aliases)
@@ -141,7 +285,6 @@ export function expandQuery(query: string) {
 		const tokenHit = tokens.some((token) =>
 			family.some((term) => {
 				if (term.includes(" ")) {
-					// Multi-word alias: require all parts present in the query.
 					const parts = term.split(" ").filter((part) => part.length > 1)
 					return parts.every(
 						(part) =>
@@ -155,6 +298,15 @@ export function expandQuery(query: string) {
 
 		if (!phraseHit && !tokenHit) continue
 
+		if (
+			canonical === "septic" ||
+			canonical === "drain" ||
+			canonical === "water heater" ||
+			canonical === "clog"
+		) {
+			intents.add("service")
+		}
+
 		for (const term of family) {
 			for (const part of term.split(" ")) {
 				if (part.length > 2 && !STOP_WORDS.has(part)) expanded.add(part)
@@ -162,11 +314,17 @@ export function expandQuery(query: string) {
 		}
 	}
 
+	const prefix = tokens.length > 0 ? (tokens[tokens.length - 1] ?? null) : null
+
 	return {
+		raw: query,
 		tokens,
 		phrase,
 		expanded: [...expanded],
 		original,
+		bigrams: ngrams(tokens, 2),
+		intents,
+		prefix: prefix && prefix.length >= 2 ? prefix : null,
 	}
 }
 
@@ -200,6 +358,11 @@ function fuzzyIncludes(haystack: string, needle: string) {
 	})
 }
 
+function prefixMatchesField(field: string, prefix: string) {
+	if (!prefix || prefix.length < 2) return false
+	return field.split(" ").some((word) => word.startsWith(prefix))
+}
+
 function scoreTokenAgainstDocument(
 	token: string,
 	fields: {
@@ -207,41 +370,87 @@ function scoreTokenAgainstDocument(
 		description: string
 		category: string
 		keywords: string
+		body: string
 	},
 ): { score: number; matchedOn: SearchHit["matchedOn"] } | null {
-	const { title, description, category, keywords } = fields
+	const { title, description, category, keywords, body } = fields
+	const titleWords = title.split(" ")
 
-	if (title === token) return { score: 120, matchedOn: "title" }
-	if (title.startsWith(`${token} `) || title.startsWith(token)) {
-		return { score: 95, matchedOn: "title" }
+	if (title === token) return { score: 130, matchedOn: "title" }
+	if (title.startsWith(`${token} `) || title === token) {
+		return { score: 100, matchedOn: "title" }
 	}
-	if (title.split(" ").includes(token) || title.includes(` ${token} `)) {
-		return { score: 80, matchedOn: "title" }
+	if (titleWords.includes(token)) return { score: 88, matchedOn: "title" }
+	if (titleWords.some((word) => lightStem(word) === lightStem(token))) {
+		return { score: 78, matchedOn: "title" }
 	}
-	if (title.includes(token)) return { score: 70, matchedOn: "title" }
-	if (category.includes(token)) return { score: 55, matchedOn: "category" }
+	if (title.includes(token)) return { score: 68, matchedOn: "title" }
+	if (
+		category.includes(token) ||
+		lightStem(category).includes(lightStem(token))
+	) {
+		return { score: 58, matchedOn: "category" }
+	}
 	if (keywords.includes(token) || fuzzyIncludes(keywords, token)) {
-		return { score: 45, matchedOn: "keyword" }
+		return { score: 48, matchedOn: "keyword" }
 	}
 	if (description.includes(token) || fuzzyIncludes(description, token)) {
-		return { score: 25, matchedOn: "description" }
+		return { score: 28, matchedOn: "description" }
 	}
-	if (fuzzyIncludes(title, token)) return { score: 50, matchedOn: "title" }
+	if (body.includes(token)) return { score: 14, matchedOn: "body" }
+	if (fuzzyIncludes(title, token)) return { score: 52, matchedOn: "title" }
 
 	return null
 }
 
+function intentBoost(document: SearchDocument, intents: Set<SearchIntent>) {
+	if (intents.size === 0) return 0
+
+	let boost = 0
+	const docIntents = new Set(document.intents ?? [])
+
+	if (
+		intents.has("call") &&
+		document.type === "action" &&
+		document.id.includes("call")
+	) {
+		boost += 80
+	}
+	if (
+		intents.has("quote") &&
+		(document.href.includes("contact") || document.id.includes("contact"))
+	) {
+		boost += 70
+	}
+	if (intents.has("tip") && document.type === "tip") boost += 36
+	if (intents.has("service") && document.type === "service") boost += 28
+	if (
+		intents.has("area") &&
+		(document.category === "Service Area" ||
+			document.href.includes("service-area"))
+	) {
+		boost += 55
+	}
+
+	for (const intent of intents) {
+		if (docIntents.has(intent)) boost += 18
+	}
+
+	return boost
+}
+
 function scoreDocument(
 	document: SearchDocument,
-	query: ReturnType<typeof expandQuery>,
+	query: ParsedQuery,
 ): SearchHit | null {
-	const { tokens, phrase, expanded, original } = query
+	const { tokens, phrase, expanded, original, bigrams, intents, prefix } = query
 
 	if (tokens.length === 0) {
 		return {
 			...document,
 			score: document.popularity ?? 0,
 			matchedOn: "title",
+			matchLabel: "Popular",
 		}
 	}
 
@@ -250,6 +459,7 @@ function scoreDocument(
 		description: normalize(document.description),
 		category: normalize(document.category ?? ""),
 		keywords: normalize(document.keywords.join(" ")),
+		body: normalize(document.body ?? ""),
 	}
 
 	let score = 0
@@ -259,16 +469,34 @@ function scoreDocument(
 
 	if (phrase.length > 3) {
 		if (fields.title.includes(phrase)) {
-			score += 160
+			score += 180
 			matchedOn = "title"
 			matchedOriginal += 1
 		} else if (fields.keywords.includes(phrase)) {
-			score += 80
+			score += 90
 			matchedOn = "keyword"
 			matchedOriginal += 1
 		} else if (fields.description.includes(phrase)) {
-			score += 45
+			score += 50
 			matchedOriginal += 1
+		} else if (fields.body.includes(phrase)) {
+			score += 24
+			matchedOn = "body"
+			matchedOriginal += 1
+		}
+	}
+
+	for (const gram of bigrams) {
+		if (fields.title.includes(gram)) {
+			score += 70
+			matchedOn = "title"
+			matchedOriginal += 0.5
+		} else if (
+			fields.keywords.includes(gram) ||
+			fields.description.includes(gram)
+		) {
+			score += 36
+			matchedOriginal += 0.25
 		}
 	}
 
@@ -277,33 +505,90 @@ function scoreDocument(
 		if (!hit) continue
 
 		const isOriginal = original.has(token)
-		const weight = isOriginal ? 1 : 0.55
+		const weight = isOriginal ? 1 : 0.5
 		score += hit.score * weight
 		matchedExpanded += 1
 		if (isOriginal) matchedOriginal += 1
-		if (
-			hit.matchedOn === "title" ||
-			(hit.matchedOn === "category" && matchedOn === "description") ||
-			(hit.matchedOn === "keyword" && matchedOn === "description")
-		) {
+
+		const rank: SearchHit["matchedOn"][] = [
+			"title",
+			"category",
+			"keyword",
+			"description",
+			"body",
+		]
+		if (rank.indexOf(hit.matchedOn) < rank.indexOf(matchedOn)) {
 			matchedOn = hit.matchedOn
 		}
 	}
 
-	if (matchedExpanded === 0) return null
+	if (prefix && prefixMatchesField(fields.title, prefix)) {
+		score += 22
+		if (matchedOn === "description" || matchedOn === "body") matchedOn = "title"
+	} else if (prefix && prefixMatchesField(fields.keywords, prefix)) {
+		score += 10
+	}
 
-	// Require at least some original-token or phrase signal when synonyms fire,
-	// unless every original token matched through stemming in the expanded set.
-	const originalCoverage = matchedOriginal / tokens.length
-	if (originalCoverage === 0 && score < 80) return null
+	if (matchedExpanded === 0 && score === 0) return null
 
-	score *= 0.6 + Math.min(1, originalCoverage) * 0.4
-	score += (document.popularity ?? 0) * 1.5
+	const originalCoverage = matchedOriginal / Math.max(tokens.length, 1)
+	if (originalCoverage === 0 && score < 90 && intents.size === 0) return null
 
-	if (document.type === "service") score += 8
-	if (document.type === "tip") score += 4
+	score *= 0.58 + Math.min(1, originalCoverage) * 0.42
+	score += (document.popularity ?? 0) * 1.35
+	score += intentBoost(document, intents)
 
-	return { ...document, score, matchedOn }
+	if (document.type === "service") score += 10
+	if (document.type === "tip") score += 5
+	if (
+		document.type === "action" &&
+		!intents.has("call") &&
+		!intents.has("quote")
+	) {
+		score -= 8
+	}
+
+	return {
+		...document,
+		score,
+		matchedOn,
+		matchLabel: MATCH_LABELS[matchedOn],
+	}
+}
+
+/** Diversify top results so one type doesn't dominate the first screen. */
+function diversifyHits(hits: SearchHit[], limit: number) {
+	if (hits.length <= limit) return hits
+
+	const selected: SearchHit[] = []
+	const remaining = [...hits]
+	const typeCounts: Record<string, number> = {}
+
+	while (selected.length < limit && remaining.length > 0) {
+		let pickIndex = 0
+		for (let i = 0; i < remaining.length; i += 1) {
+			const candidate = remaining[i]
+			if (!candidate) continue
+			const count = typeCounts[candidate.type] ?? 0
+			const leader = remaining[pickIndex]
+			if (!leader) {
+				pickIndex = i
+				continue
+			}
+			const leaderCount = typeCounts[leader.type] ?? 0
+			// Prefer under-represented types when scores are close.
+			if (count < leaderCount && candidate.score >= leader.score * 0.82) {
+				pickIndex = i
+			}
+		}
+
+		const [picked] = remaining.splice(pickIndex, 1)
+		if (!picked) break
+		selected.push(picked)
+		typeCounts[picked.type] = (typeCounts[picked.type] ?? 0) + 1
+	}
+
+	return selected
 }
 
 export function searchDocuments(
@@ -324,14 +609,16 @@ export function searchDocuments(
 				...document,
 				score: document.popularity ?? 0,
 				matchedOn: "title" as const,
+				matchLabel: "Popular",
 			}))
 	}
 
-	return documents
+	const ranked = documents
 		.map((document) => scoreDocument(document, parsed))
 		.filter((hit): hit is SearchHit => hit !== null)
 		.sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
-		.slice(0, limit)
+
+	return diversifyHits(ranked, limit)
 }
 
 export function groupSearchHits(hits: SearchHit[]) {
@@ -347,4 +634,79 @@ export function groupSearchHits(hits: SearchHit[]) {
 	}
 
 	return groups
+}
+
+/** Adaptive suggestion chips from the current query + synonym families. */
+export function suggestSearches(query: string, limit = 6): string[] {
+	const phrase = normalize(query)
+	const tokens = tokenize(query)
+	const suggestions = new Set<string>()
+
+	const defaults = [
+		"clogged drain",
+		"septic pumping",
+		"water heater",
+		"toilet repair",
+		"leak detection",
+		"hydro jetting",
+	]
+
+	if (!phrase) return defaults.slice(0, limit)
+
+	for (const [canonical, aliases] of Object.entries(SEARCH_SYNONYMS)) {
+		const family = familyTerms(canonical, aliases)
+		const related = family.some(
+			(term) =>
+				phrase.includes(term) ||
+				term.includes(phrase) ||
+				tokens.some((token) =>
+					tokenMatchesTerm(token, term.split(" ")[0] ?? ""),
+				),
+		)
+		if (!related) continue
+		suggestions.add(canonical)
+		for (const alias of aliases.slice(0, 2)) suggestions.add(alias)
+	}
+
+	for (const item of defaults) {
+		if (item.includes(phrase) || phrase.length < 3) suggestions.add(item)
+	}
+
+	return [...suggestions].filter((item) => item !== phrase).slice(0, limit)
+}
+
+/** Highlight query terms inside a title for rich results. */
+export function highlightMatches(
+	text: string,
+	query: string,
+): Array<{
+	text: string
+	match: boolean
+}> {
+	const tokens = [...new Set(expandQuery(query).tokens.map(lightStem))].filter(
+		(token) => token.length > 1,
+	)
+	if (!tokens.length) return [{ text, match: false }]
+
+	const pattern = new RegExp(
+		`(${tokens
+			.map((token) => token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+			.join("|")})`,
+		"ig",
+	)
+
+	const parts: Array<{ text: string; match: boolean }> = []
+	let lastIndex = 0
+	for (const match of text.matchAll(pattern)) {
+		const index = match.index ?? 0
+		if (index > lastIndex) {
+			parts.push({ text: text.slice(lastIndex, index), match: false })
+		}
+		parts.push({ text: match[0] ?? "", match: true })
+		lastIndex = index + (match[0]?.length ?? 0)
+	}
+	if (lastIndex < text.length) {
+		parts.push({ text: text.slice(lastIndex), match: false })
+	}
+	return parts.length ? parts : [{ text, match: false }]
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
 		"format:check": "prettier --check .",
 		"ci:content": "node scripts/ci/validate-content.mjs",
 		"ci:self-hosted-policy": "node scripts/ci/assert-self-hosted-only.mjs",
+		"ci:search": "npx --yes tsx scripts/ci/test-search.ts",
 		"migrate:wayback": "python3 -u scripts/migrate-from-wayback.py",
-		"check": "npm run lint && npm run typecheck && npm run format:check && npm run build"
+		"check": "npm run lint && npm run typecheck && npm run format:check && npm run ci:search && npm run build"
 	},
 	"dependencies": {
 		"@radix-ui/react-accordion": "1.2.20",

--- a/scripts/ci/test-search.ts
+++ b/scripts/ci/test-search.ts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict"
+
+import {
+	expandQuery,
+	highlightMatches,
+	searchDocuments,
+	suggestSearches,
+	type SearchDocument,
+} from "../../lib/search"
+
+const docs: SearchDocument[] = [
+	{
+		id: "service:drain",
+		type: "service",
+		title: "Drain Cleaning",
+		description: "Clear clogged and slow drains.",
+		href: "/service-offerings/drain-cleaning",
+		category: "Plumbing",
+		keywords: ["drain", "clog", "cleaning", "backup"],
+		body: "Hair soap grease roots create similar symptoms.",
+		popularity: 48,
+		intents: ["service"],
+	},
+	{
+		id: "service:septic-pump",
+		type: "service",
+		title: "Septic Tank Cleaning and Pumping",
+		description: "Pump and clean septic tanks.",
+		href: "/service-offerings/septic-tank-cleaning-and-pumping",
+		category: "Septic",
+		keywords: ["septic", "pumping", "tank", "cleaning"],
+		body: "Routine pumping protects the drain field.",
+		popularity: 47,
+		intents: ["service"],
+	},
+	{
+		id: "service:heater",
+		type: "service",
+		title: "Water Heater Installation",
+		description: "Install tank and tankless water heaters.",
+		href: "/service-offerings/water-heater-installation",
+		category: "Plumbing",
+		keywords: ["water", "heater", "tankless", "hot"],
+		popularity: 41,
+		intents: ["service"],
+	},
+	{
+		id: "tip:clog",
+		type: "tip",
+		title: "How to Properly Clear a Clogged Drain",
+		description: "Troubleshoot a simple fixture clog.",
+		href: "/how-to-clear",
+		category: "DIY Projects",
+		keywords: ["clogged", "drain", "diy", "guide"],
+		body: "Multiple slow drains can indicate a main-line problem.",
+		popularity: 20,
+		intents: ["tip"],
+	},
+	{
+		id: "action:call",
+		type: "action",
+		title: "Call 831.225.4344",
+		description: "Speak with Wade's during business hours.",
+		href: "tel:+18312254344",
+		category: "Action",
+		keywords: ["call", "phone", "schedule"],
+		popularity: 55,
+		intents: ["call"],
+	},
+	{
+		id: "action:quote",
+		type: "action",
+		title: "Get a Free Quote",
+		description: "Request an estimate.",
+		href: "/contact",
+		category: "Action",
+		keywords: ["quote", "estimate", "cost", "price"],
+		popularity: 50,
+		intents: ["quote"],
+	},
+	{
+		id: "page:aptos",
+		type: "page",
+		title: "Plumbing & Septic in Aptos",
+		description: "Local service in Aptos, CA.",
+		href: "/service-area/aptos-ca-plumbing-septic-services",
+		category: "Service Area",
+		keywords: ["aptos", "santa", "cruz", "area"],
+		popularity: 12,
+		intents: ["area", "service"],
+	},
+]
+
+function topTitles(query: string, limit = 3) {
+	return searchDocuments(docs, query, limit).map((hit) => hit.title)
+}
+
+function assertIncludes(actual: string[], expected: string, message: string) {
+	assert.ok(
+		actual.some((item) => item.toLowerCase().includes(expected.toLowerCase())),
+		`${message}\n  got: ${JSON.stringify(actual)}`,
+	)
+}
+
+function assertFirstIncludes(
+	actual: string[],
+	expected: string,
+	message: string,
+) {
+	assert.ok(
+		actual[0]?.toLowerCase().includes(expected.toLowerCase()),
+		`${message}\n  got: ${JSON.stringify(actual)}`,
+	)
+}
+
+assertFirstIncludes(
+	topTitles("clogged drain"),
+	"Drain",
+	"clogged drain → drain service",
+)
+assertFirstIncludes(topTitles("drain"), "Drain", "drain → drain service")
+assertFirstIncludes(
+	topTitles("septic pumping"),
+	"Septic",
+	"septic pumping → septic",
+)
+assertFirstIncludes(
+	topTitles("no hot water"),
+	"Water Heater",
+	"no hot water → heater",
+)
+assertIncludes(topTitles("how much for a quote", 5), "Quote", "quote intent")
+assertIncludes(topTitles("call a plumber", 5), "Call", "call intent")
+assertIncludes(
+	topTitles("how to clear a clog", 5),
+	"Clogged",
+	"how-to boosts tip",
+)
+assertIncludes(topTitles("aptos near me", 5), "Aptos", "area query")
+assertFirstIncludes(topTitles("heat"), "Water Heater", "prefix heat → heater")
+
+assert.ok(suggestSearches("clog").length > 0, "suggestions for clog")
+assert.ok(
+	highlightMatches("Drain Cleaning", "drain").some((part) => part.match),
+	"highlight matches drain",
+)
+
+const expanded = expandQuery("sewage smell")
+assert.ok(
+	expanded.expanded.includes("septic") || expanded.expanded.includes("odor"),
+	"sewage smell expands",
+)
+
+console.log("Search quality checks passed ✓")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Upgrades sitewide search so it understands homeowner language, symptoms, and intent—not just keywords—and surfaces richer, better-ranked results.

## Improvements
- **Intent detection** for call / quote / how-to / near-me style queries
- **Symptom phrases** like “no hot water”, “sewage smell”, “slow drain”, “gurgling”
- **Richer index**: body excerpts, category hubs, service-area cities, featured popularity, service boost keywords
- **Smarter ranking**: bigrams, prefix matching while typing, stem tolerance, result diversification
- **Richer UI**: title highlights, match labels, adaptive suggestion chips, better empty state
- **CI guardrail**: `npm run ci:search` quality assertions (wired into `npm run check`)

## Test plan
- [ ] Search `clogged drain` → drain services first (not septic)
- [ ] Search `no hot water`, `sewage smell`, `how to clear a clog`, `quote`, `aptos near me`
- [ ] Type `heat` progressively and confirm water heater appears
- [ ] Confirm highlighted titles + match labels on desktop
- [ ] Confirm suggestion chips update with the query
- [ ] `npm run ci:search` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

