### PR TITLE
Add Vercel Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next"
+import { Analytics } from "@vercel/analytics/next"
 import { Manrope } from "next/font/google"
 import { Suspense } from "react"
 
@@ -140,6 +141,7 @@ export default function RootLayout({
 					<SiteFooter />
 					<CommandMenuLoader />
 					<JsonLd data={localBusinessSchema} />
+					<Analytics />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,22 +9,23 @@
 			"version": "2.0.0",
 			"dependencies": {
 				"@radix-ui/react-accordion": "1.2.20",
-				"@radix-ui/react-dialog": "^1.1.23",
-				"@radix-ui/react-navigation-menu": "^1.2.22",
-				"@radix-ui/react-separator": "^1.1.15",
-				"@radix-ui/react-slot": "^1.3.3",
+				"@radix-ui/react-dialog": "1.1.23",
+				"@radix-ui/react-navigation-menu": "1.2.22",
+				"@radix-ui/react-separator": "1.1.15",
+				"@radix-ui/react-slot": "1.3.3",
+				"@vercel/analytics": "^2.0.1",
 				"class-variance-authority": "0.7.1",
 				"clsx": "2.1.1",
-				"cmdk": "^1.1.1",
+				"cmdk": "1.1.1",
 				"gray-matter": "4.0.3",
 				"lucide-react": "1.27.0",
 				"next": "16.3.0-preview.10",
-				"next-themes": "^0.4.6",
+				"next-themes": "0.4.6",
 				"react": "19.2.8",
 				"react-dom": "19.2.8",
 				"react-markdown": "10.1.0",
 				"remark-gfm": "4.0.1",
-				"sonner": "^2.0.7",
+				"sonner": "2.0.7",
 				"tailwind-merge": "3.6.0"
 			},
 			"devDependencies": {
@@ -2305,6 +2306,7 @@
 			"version": "19.2.17",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
 			"integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -2314,7 +2316,7 @@
 			"version": "19.2.3",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
@@ -2727,6 +2729,48 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@vercel/analytics": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+			"integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@remix-run/react": "^2",
+				"@sveltejs/kit": "^1 || ^2",
+				"next": ">= 13",
+				"nuxt": ">= 3",
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"svelte": ">= 4",
+				"vue": "^3",
+				"vue-router": "^4"
+			},
+			"peerDependenciesMeta": {
+				"@remix-run/react": {
+					"optional": true
+				},
+				"@sveltejs/kit": {
+					"optional": true
+				},
+				"next": {
+					"optional": true
+				},
+				"nuxt": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				},
+				"svelte": {
+					"optional": true
+				},
+				"vue": {
+					"optional": true
+				},
+				"vue-router": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/acorn": {
 			"version": "8.18.0",
@@ -3368,6 +3412,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/damerau-levenshtein": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"@radix-ui/react-navigation-menu": "1.2.22",
 		"@radix-ui/react-separator": "1.1.15",
 		"@radix-ui/react-slot": "1.3.3",
+		"@vercel/analytics": "^2.0.1",
 		"class-variance-authority": "0.7.1",
 		"clsx": "2.1.1",
 		"cmdk": "1.1.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Installs `@vercel/analytics` and mounts the App Router `<Analytics />` component in the root layout.

## Notes
- Installed with `--legacy-peer-deps` because this repo uses Next.js `16.3.0-preview.10`, which npm’s peer resolver doesn’t treat cleanly against the package’s optional `next >= 13` peer.

## Test plan
- [ ] Confirm package is present in `package.json`
- [ ] Deploy/preview and verify Vercel Analytics starts receiving pageviews
- [ ] Confirm the site still loads with no client errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019faf50-f7c6-714a-8833-9a7358320ab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

