### PR TITLE
Add Linear-style filters and pagination to services & expert tips

### DIFF
--- a/app/expert-tips/page.tsx
+++ b/app/expert-tips/page.tsx
@@ -1,20 +1,10 @@
 import type { Metadata } from "next"
-import type { Route } from "next"
-import Image from "next/image"
-import Link from "next/link"
-import { ArrowRight, CalendarDays } from "lucide-react"
 import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
-import { Badge } from "@/components/ui/badge"
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card"
+import { FilterableArchive } from "@/components/filterable-archive"
+import { toArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -26,97 +16,23 @@ export const metadata: Metadata = buildPageMetadata({
 	image: "/images/team/byron-working.webp",
 })
 
-const FEATURED_COUNT = 9
-
 async function TipsGrid() {
 	"use cache"
 
 	const posts = await getCollection("posts")
-	const featured = posts.slice(0, FEATURED_COUNT)
-	const remaining = posts.slice(FEATURED_COUNT)
+	const items = posts.map((post) =>
+		toArchiveItem(post, `/${post.slug}`, post.category ?? "Expert Tips"),
+	)
 
 	return (
-		<section className="container-shell section-y">
-			<div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-				{featured.map((post) => (
-					<Card
-						className="group flex h-full flex-col overflow-hidden"
-						key={post.slug}
-					>
-						<Link
-							aria-label={`Read ${post.title}`}
-							className="bg-muted relative block aspect-[16/9] overflow-hidden"
-							href={`/${post.slug}` as Route}
-							prefetch={false}
-							tabIndex={-1}
-						>
-							<Image
-								alt=""
-								className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-								fill
-								quality={60}
-								sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-								src={
-									post.image ?? "/images/work/precision-valve-installation.webp"
-								}
-							/>
-						</Link>
-						<CardHeader>
-							<Badge className="w-fit" tone="muted">
-								{post.category ?? "Expert Tips"}
-							</Badge>
-							<CardTitle className="group-hover:text-primary mt-3">
-								<Link href={`/${post.slug}` as Route} prefetch={false}>
-									{post.title}
-								</Link>
-							</CardTitle>
-							<CardDescription>{post.description}</CardDescription>
-						</CardHeader>
-						<CardContent className="mt-auto">
-							{post.date ? (
-								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
-									<CalendarDays className="text-primary size-4" />
-									{post.date}
-								</p>
-							) : null}
-							<Link
-								className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
-								href={`/${post.slug}` as Route}
-								prefetch={false}
-							>
-								Read guide
-								<ArrowRight className="size-4" />
-							</Link>
-						</CardContent>
-					</Card>
-				))}
-			</div>
-
-			{remaining.length > 0 ? (
-				<div className="mt-12">
-					<h2 className="type-title text-2xl">More guides</h2>
-					<ul className="mt-6 divide-y divide-[var(--border)] border-y border-[var(--border)]">
-						{remaining.map((post) => (
-							<li key={post.slug}>
-								<Link
-									className="hover:bg-muted/60 flex flex-col gap-1 py-4 transition-colors sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
-									href={`/${post.slug}` as Route}
-									prefetch={false}
-								>
-									<span className="font-extrabold tracking-[-0.02em]">
-										{post.title}
-									</span>
-									<span className="text-muted-foreground text-sm">
-										{post.category ?? "Expert Tips"}
-										{post.date ? ` · ${post.date}` : ""}
-									</span>
-								</Link>
-							</li>
-						))}
-					</ul>
-				</div>
-			) : null}
-		</section>
+		<FilterableArchive
+			allLabel="All guides"
+			emptyLabel="No guides in this category."
+			items={items}
+			noun={{ singular: "guide", plural: "guides" }}
+			pageSize={9}
+			variant="tip"
+		/>
 	)
 }
 

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -4,7 +4,8 @@ import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
-import { ServiceCard } from "@/components/service-card"
+import { FilterableArchive } from "@/components/filterable-archive"
+import { toArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -120,11 +121,21 @@ export default async function ServiceCategoryPage({
 					</section>
 				}
 			>
-				<section className="container-shell section-y grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-					{services.map((service) => (
-						<ServiceCard key={service.slug} service={service} />
-					))}
-				</section>
+				<FilterableArchive
+					allLabel={`${category.label} services`}
+					emptyLabel="No services in this category."
+					items={services.map((service) =>
+						toArchiveItem(
+							service,
+							`/service-offerings/${service.slug}`,
+							service.category ?? category.contentCategory,
+						),
+					)}
+					noun={{ singular: "service", plural: "services" }}
+					pageSize={12}
+					showFilters={false}
+					variant="service"
+				/>
 			</Suspense>
 			<ContactCta />
 		</main>

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -3,7 +3,8 @@ import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
-import { ServiceCard } from "@/components/service-card"
+import { FilterableArchive } from "@/components/filterable-archive"
+import { toArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -19,38 +20,23 @@ async function ServiceDirectory() {
 	"use cache"
 
 	const services = await getCollection("services")
-	const categories = ["Septic", "Plumbing", "Commercial"] as const
+	const items = services.map((service) =>
+		toArchiveItem(
+			service,
+			`/service-offerings/${service.slug}`,
+			service.category ?? "Plumbing",
+		),
+	)
 
 	return (
-		<div className="container-shell section-y space-y-16">
-			{categories.map((category) => {
-				const categoryServices = services.filter(
-					(service) => service.category === category,
-				)
-
-				if (!categoryServices.length) return null
-
-				return (
-					<section key={category}>
-						<div className="border-border mb-7 flex items-end justify-between gap-5 border-b pb-5">
-							<div>
-								<p className="type-eyebrow">
-									{categoryServices.length} services
-								</p>
-								<h2 className="mt-2 text-3xl font-extrabold tracking-[-0.03em]">
-									{category}
-								</h2>
-							</div>
-						</div>
-						<div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-							{categoryServices.map((service) => (
-								<ServiceCard key={service.slug} service={service} />
-							))}
-						</div>
-					</section>
-				)
-			})}
-		</div>
+		<FilterableArchive
+			allLabel="All services"
+			emptyLabel="No services in this category."
+			items={items}
+			noun={{ singular: "service", plural: "services" }}
+			pageSize={12}
+			variant="service"
+		/>
 	)
 }
 

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -1,18 +1,9 @@
-import type { Route } from "next"
-import Image from "next/image"
-import Link from "next/link"
-import { ArrowRight, CalendarDays } from "lucide-react"
+import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
-import { Badge } from "@/components/ui/badge"
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card"
+import { FilterableArchive } from "@/components/filterable-archive"
+import { toArchiveItem } from "@/lib/archive"
 import type { ContentDocument } from "@/lib/content"
 
 export function ArticleArchive({
@@ -24,6 +15,10 @@ export function ArticleArchive({
 	description: string
 	posts: ContentDocument[]
 }) {
+	const items = posts.map((post) =>
+		toArchiveItem(post, `/${post.slug}`, post.category ?? "Expert Tips"),
+	)
+
 	return (
 		<main id="main-content">
 			<ContentHero
@@ -34,60 +29,23 @@ export function ArticleArchive({
 				parent={{ href: "/expert-tips", label: "Expert Tips" }}
 				title={title}
 			/>
-			<section className="container-shell section-y grid gap-5 md:grid-cols-2 lg:grid-cols-3">
-				{posts.map((post) => (
-					<Card
-						className="group flex h-full flex-col overflow-hidden"
-						key={post.slug}
-					>
-						<Link
-							aria-label={`Read ${post.title}`}
-							className="bg-muted relative block aspect-[16/9] overflow-hidden"
-							href={`/${post.slug}` as Route}
-							prefetch={false}
-							tabIndex={-1}
-						>
-							<Image
-								alt=""
-								className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
-								fill
-								quality={60}
-								sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-								src={
-									post.image ?? "/images/work/precision-valve-installation.webp"
-								}
-							/>
-						</Link>
-						<CardHeader>
-							<Badge className="w-fit" tone="muted">
-								{post.category ?? "Expert Tips"}
-							</Badge>
-							<CardTitle className="group-hover:text-primary mt-3">
-								<Link href={`/${post.slug}` as Route} prefetch={false}>
-									{post.title}
-								</Link>
-							</CardTitle>
-							<CardDescription>{post.description}</CardDescription>
-						</CardHeader>
-						<CardContent className="mt-auto">
-							{post.date ? (
-								<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
-									<CalendarDays className="text-primary size-4" />
-									{post.date}
-								</p>
-							) : null}
-							<Link
-								className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
-								href={`/${post.slug}` as Route}
-								prefetch={false}
-							>
-								Read guide
-								<ArrowRight className="size-4" />
-							</Link>
-						</CardContent>
-					</Card>
-				))}
-			</section>
+			<Suspense
+				fallback={
+					<section className="container-shell section-y">
+						Loading guides…
+					</section>
+				}
+			>
+				<FilterableArchive
+					allLabel={title}
+					emptyLabel="No guides in this category."
+					items={items}
+					noun={{ singular: "guide", plural: "guides" }}
+					pageSize={9}
+					showFilters={false}
+					variant="tip"
+				/>
+			</Suspense>
 			<ContactCta title="Need professional help?" />
 		</main>
 	)

--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -1,0 +1,315 @@
+"use client"
+
+import type { Route } from "next"
+import Image from "next/image"
+import Link from "next/link"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
+import { ArrowLeft, ArrowRight, CalendarDays } from "lucide-react"
+import { startTransition, useEffect, useMemo } from "react"
+
+import { Badge } from "@/components/ui/badge"
+import { buttonVariants } from "@/components/ui/button"
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card"
+import {
+	type ArchiveItem,
+	buildArchiveFilters,
+	filterArchiveItems,
+	paginateArchiveItems,
+} from "@/lib/archive"
+import { getServiceImage } from "@/lib/service-images"
+import { cn } from "@/lib/utils"
+
+const DEFAULT_PAGE_SIZE = 12
+
+function parsePage(value: string | null) {
+	const page = Number(value ?? "1")
+	return Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1
+}
+
+function ArchiveCard({
+	item,
+	variant,
+}: {
+	item: ArchiveItem
+	variant: "service" | "tip"
+}) {
+	const image =
+		variant === "service"
+			? getServiceImage(item.category, item.image)
+			: (item.image ?? "/images/work/precision-valve-installation.webp")
+
+	return (
+		<Card className="group hover:border-primary/35 flex h-full flex-col overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5">
+			<Link
+				aria-label={
+					variant === "service" ? `View ${item.title}` : `Read ${item.title}`
+				}
+				className="bg-muted relative block aspect-[16/9] overflow-hidden"
+				href={item.href as Route}
+				prefetch={false}
+				tabIndex={-1}
+			>
+				<Image
+					alt=""
+					className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+					fill
+					quality={60}
+					sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
+					src={image}
+				/>
+			</Link>
+			<CardHeader>
+				<Badge className="w-fit" tone="muted">
+					{item.category}
+				</Badge>
+				<CardTitle className="group-hover:text-primary mt-3 transition-colors">
+					<Link href={item.href as Route} prefetch={false}>
+						{item.title}
+					</Link>
+				</CardTitle>
+				<CardDescription>{item.description}</CardDescription>
+			</CardHeader>
+			<CardContent className="mt-auto">
+				{variant === "tip" && item.date ? (
+					<p className="text-muted-foreground mb-4 flex items-center gap-2 text-xs font-bold">
+						<CalendarDays className="text-primary size-4" />
+						{item.date}
+					</p>
+				) : null}
+				<Link
+					className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
+					href={item.href as Route}
+					prefetch={false}
+				>
+					{variant === "service" ? "Learn more" : "Read guide"}
+					<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+				</Link>
+			</CardContent>
+		</Card>
+	)
+}
+
+export function FilterableArchive({
+	items,
+	variant,
+	pageSize = DEFAULT_PAGE_SIZE,
+	allLabel = "All",
+	emptyLabel = "No results in this filter.",
+	noun = { singular: "item", plural: "items" },
+	showFilters = true,
+}: {
+	items: ArchiveItem[]
+	variant: "service" | "tip"
+	pageSize?: number
+	allLabel?: string
+	emptyLabel?: string
+	noun?: { singular: string; plural: string }
+	showFilters?: boolean
+}) {
+	const router = useRouter()
+	const pathname = usePathname()
+	const searchParams = useSearchParams()
+
+	const activeCategory = searchParams.get("category")
+	const requestedPage = parsePage(searchParams.get("page"))
+
+	const filters = useMemo(() => buildArchiveFilters(items), [items])
+	const canFilter = showFilters && filters.length > 1
+	const filtered = useMemo(
+		() => (canFilter ? filterArchiveItems(items, activeCategory) : items),
+		[items, activeCategory, canFilter],
+	)
+	const { page, pageCount, pageItems, total } = useMemo(
+		() => paginateArchiveItems(filtered, requestedPage, pageSize),
+		[filtered, requestedPage, pageSize],
+	)
+
+	useEffect(() => {
+		if (requestedPage === page) return
+		const params = new URLSearchParams(searchParams.toString())
+		if (page <= 1) params.delete("page")
+		else params.set("page", String(page))
+		const query = params.toString()
+		router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+	}, [page, pathname, requestedPage, router, searchParams])
+
+	function updateParams(
+		next: { category?: string | null; page?: number },
+		options?: { scrollToFilters?: boolean },
+	) {
+		const params = new URLSearchParams(searchParams.toString())
+
+		if ("category" in next) {
+			if (!next.category || next.category === "all") params.delete("category")
+			else params.set("category", next.category)
+			params.delete("page")
+		}
+
+		if ("page" in next && typeof next.page === "number") {
+			if (next.page <= 1) params.delete("page")
+			else params.set("page", String(next.page))
+		}
+
+		const query = params.toString()
+		startTransition(() => {
+			router.replace(query ? `${pathname}?${query}` : pathname, {
+				scroll: false,
+			})
+			if (options?.scrollToFilters) {
+				document
+					.getElementById("archive-filters")
+					?.scrollIntoView({ behavior: "smooth", block: "start" })
+			}
+		})
+	}
+
+	const countLabel = `${total} ${total === 1 ? noun.singular : noun.plural}`
+	const activeFilter = filters.find((filter) => filter.key === activeCategory)
+
+	return (
+		<section className="container-shell section-y">
+			<div className="border-border mb-8 border-b pb-5" id="archive-filters">
+				<div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+					<div>
+						<p className="type-eyebrow">{countLabel}</p>
+						<h2 className="mt-2 text-3xl font-extrabold tracking-[-0.03em]">
+							{activeFilter && canFilter ? activeFilter.label : allLabel}
+						</h2>
+					</div>
+					{canFilter ? (
+						<p className="text-muted-foreground text-sm lg:max-w-sm lg:text-right">
+							Filter instantly, then page through results.
+						</p>
+					) : null}
+				</div>
+
+				{canFilter ? (
+					<div
+						aria-label="Filter by category"
+						className="mt-5 flex [scrollbar-width:none] gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+						role="tablist"
+					>
+						<button
+							aria-selected={!activeCategory || activeCategory === "all"}
+							className={cn(
+								"inline-flex shrink-0 items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-bold transition-colors",
+								!activeCategory || activeCategory === "all"
+									? "border-ink bg-ink text-white"
+									: "border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
+							)}
+							onClick={() => updateParams({ category: "all" })}
+							role="tab"
+							type="button"
+						>
+							{allLabel}
+							<span
+								className={cn(
+									"rounded px-1.5 py-0.5 text-xs font-extrabold tabular-nums",
+									!activeCategory || activeCategory === "all"
+										? "bg-white/15 text-white"
+										: "bg-muted text-muted-foreground",
+								)}
+							>
+								{items.length}
+							</span>
+						</button>
+						{filters.map((filter) => {
+							const selected = activeCategory === filter.key
+							return (
+								<button
+									aria-selected={selected}
+									className={cn(
+										"inline-flex shrink-0 items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-bold transition-colors",
+										selected
+											? "border-ink bg-ink text-white"
+											: "border-border bg-card text-foreground hover:border-foreground/25 hover:bg-muted",
+									)}
+									key={filter.key}
+									onClick={() => updateParams({ category: filter.key })}
+									role="tab"
+									type="button"
+								>
+									{filter.label}
+									<span
+										className={cn(
+											"rounded px-1.5 py-0.5 text-xs font-extrabold tabular-nums",
+											selected
+												? "bg-white/15 text-white"
+												: "bg-muted text-muted-foreground",
+										)}
+									>
+										{filter.count}
+									</span>
+								</button>
+							)
+						})}
+					</div>
+				) : null}
+			</div>
+
+			{pageItems.length ? (
+				<div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+					{pageItems.map((item) => (
+						<ArchiveCard item={item} key={item.slug} variant={variant} />
+					))}
+				</div>
+			) : (
+				<p className="text-muted-foreground py-16 text-center text-sm font-bold">
+					{emptyLabel}
+				</p>
+			)}
+
+			{pageCount > 1 ? (
+				<nav
+					aria-label="Pagination"
+					className="border-border mt-10 flex flex-col items-stretch justify-between gap-4 border-t pt-6 sm:flex-row sm:items-center"
+				>
+					<p className="text-muted-foreground text-sm font-bold tabular-nums">
+						Page {page} of {pageCount}
+						<span className="text-muted-foreground/80 font-medium">
+							{" "}
+							· showing {(page - 1) * pageSize + 1}–
+							{Math.min(page * pageSize, total)} of {total}
+						</span>
+					</p>
+					<div className="flex items-center gap-2">
+						<button
+							className={cn(
+								buttonVariants({ variant: "outline", size: "sm" }),
+								"min-w-28",
+							)}
+							disabled={page <= 1}
+							onClick={() =>
+								updateParams({ page: page - 1 }, { scrollToFilters: true })
+							}
+							type="button"
+						>
+							<ArrowLeft />
+							Previous
+						</button>
+						<button
+							className={cn(
+								buttonVariants({ variant: "outline", size: "sm" }),
+								"min-w-28",
+							)}
+							disabled={page >= pageCount}
+							onClick={() =>
+								updateParams({ page: page + 1 }, { scrollToFilters: true })
+							}
+							type="button"
+						>
+							Next
+							<ArrowRight />
+						</button>
+					</div>
+				</nav>
+			) : null}
+		</section>
+	)
+}

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -1,0 +1,121 @@
+export type ArchiveItem = {
+	slug: string
+	title: string
+	description: string
+	category: string
+	href: string
+	image?: string
+	imageAlt?: string
+	date?: string
+}
+
+export type ArchiveFilter = {
+	key: string
+	label: string
+	count: number
+}
+
+/** Shorter chip labels for long WordPress category names. */
+const SHORT_LABELS: Record<string, string> = {
+	"Septic Issues in Santa Cruz County": "Septic Issues",
+	"Plumbing Maintenance": "Maintenance",
+	"Plumbing Tips": "Plumbing Tips",
+	"Septic Maintenance": "Septic Care",
+	"DIY Projects": "DIY",
+	"Santa Cruz Plumbing": "Santa Cruz",
+}
+
+export function archiveCategoryKey(category: string) {
+	return category
+		.toLowerCase()
+		.replace(/&/g, "and")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-|-$/g, "")
+}
+
+export function archiveCategoryLabel(category: string) {
+	return SHORT_LABELS[category] ?? category
+}
+
+export function toArchiveItem(
+	document: {
+		slug: string
+		title: string
+		description: string
+		category?: string
+		image?: string
+		imageAlt?: string
+		date?: string
+	},
+	href: string,
+	fallbackCategory: string,
+): ArchiveItem {
+	return {
+		slug: document.slug,
+		title: document.title,
+		description: document.description,
+		category: document.category ?? fallbackCategory,
+		href,
+		image: document.image,
+		imageAlt: document.imageAlt,
+		date: document.date,
+	}
+}
+
+export function buildArchiveFilters(items: ArchiveItem[]): ArchiveFilter[] {
+	const counts = new Map<string, { label: string; count: number }>()
+
+	for (const item of items) {
+		const key = archiveCategoryKey(item.category)
+		const existing = counts.get(key)
+		if (existing) {
+			existing.count += 1
+		} else {
+			counts.set(key, {
+				label: archiveCategoryLabel(item.category),
+				count: 1,
+			})
+		}
+	}
+
+	return [...counts.entries()]
+		.map(([key, value]) => ({
+			key,
+			label: value.label,
+			count: value.count,
+		}))
+		.sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+}
+
+export function filterArchiveItems(
+	items: ArchiveItem[],
+	categoryKey: string | null,
+): ArchiveItem[] {
+	if (!categoryKey || categoryKey === "all") return items
+	return items.filter(
+		(item) => archiveCategoryKey(item.category) === categoryKey,
+	)
+}
+
+export function paginateArchiveItems<T>(
+	items: T[],
+	page: number,
+	pageSize: number,
+): {
+	page: number
+	pageCount: number
+	pageItems: T[]
+	total: number
+} {
+	const total = items.length
+	const pageCount = Math.max(1, Math.ceil(total / pageSize) || 1)
+	const safePage = Math.min(Math.max(1, page), pageCount)
+	const start = (safePage - 1) * pageSize
+
+	return {
+		page: safePage,
+		pageCount,
+		pageItems: items.slice(start, start + pageSize),
+		total,
+	}
+}

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
 		"ci:content": "node scripts/ci/validate-content.mjs",
 		"ci:self-hosted-policy": "node scripts/ci/assert-self-hosted-only.mjs",
 		"ci:search": "npx --yes tsx scripts/ci/test-search.ts",
+		"ci:archive": "npx --yes tsx scripts/ci/test-archive.ts",
 		"migrate:wayback": "python3 -u scripts/migrate-from-wayback.py",
 		"migrate:wordpress": "python3 -u scripts/migrate-from-wordpress-csv.py",
 		"migrate:wordpress-images": "python3 -u scripts/migrate-wordpress-images.py",
-		"check": "npm run lint && npm run typecheck && npm run format:check && npm run ci:search && npm run build"
+		"check": "npm run lint && npm run typecheck && npm run format:check && npm run ci:search && npm run ci:archive && npm run build"
 	},
 	"dependencies": {
 		"@radix-ui/react-accordion": "1.2.20",

--- a/scripts/ci/test-archive.ts
+++ b/scripts/ci/test-archive.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict"
+
+import {
+	archiveCategoryKey,
+	buildArchiveFilters,
+	filterArchiveItems,
+	paginateArchiveItems,
+	toArchiveItem,
+} from "../../lib/archive"
+
+const items = [
+	toArchiveItem(
+		{
+			slug: "a",
+			title: "Drain Cleaning",
+			description: "Clear drains",
+			category: "Plumbing",
+		},
+		"/service-offerings/a",
+		"Plumbing",
+	),
+	toArchiveItem(
+		{
+			slug: "b",
+			title: "Septic Pumping",
+			description: "Pump tanks",
+			category: "Septic",
+		},
+		"/service-offerings/b",
+		"Plumbing",
+	),
+	toArchiveItem(
+		{
+			slug: "c",
+			title: "Commercial Drain",
+			description: "Biz drains",
+			category: "Commercial",
+		},
+		"/service-offerings/c",
+		"Plumbing",
+	),
+	toArchiveItem(
+		{
+			slug: "d",
+			title: "Leak Detection",
+			description: "Find leaks",
+			category: "Plumbing",
+		},
+		"/service-offerings/d",
+		"Plumbing",
+	),
+]
+
+assert.equal(archiveCategoryKey("Plumbing Tips"), "plumbing-tips")
+
+const filters = buildArchiveFilters(items)
+assert.equal(filters[0]?.key, "plumbing")
+assert.equal(filters[0]?.count, 2)
+assert.equal(filters.length, 3)
+
+const plumbing = filterArchiveItems(items, "plumbing")
+assert.equal(plumbing.length, 2)
+
+const page1 = paginateArchiveItems(items, 1, 2)
+assert.equal(page1.pageCount, 2)
+assert.equal(page1.pageItems.length, 2)
+assert.equal(page1.page, 1)
+
+const pageOverflow = paginateArchiveItems(items, 99, 2)
+assert.equal(pageOverflow.page, 2)
+
+console.log("archive helpers ok")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The services page used static “N services” category sections that looked filter-like but weren’t interactive, and expert tips dumped everything into a featured grid + long list. Both archives now share a Linear-style filter chip bar and prev/next pagination.

## What changed

- New `FilterableArchive` client component:
  - Instant category chips with live counts (`All 49`, `Plumbing 24`, …)
  - Accurate filtered totals in the eyebrow/heading
  - Previous / Next pagination with “Page X of Y”
  - URL sync: `?category=septic&page=2` (shareable / back-button friendly)
- `/services` and `/expert-tips` use the new archive
- `/service-category/*` and category article archives get the same pagination
- Helpers + CI check in `lib/archive.ts` / `scripts/ci/test-archive.ts`

## UX notes

- Chips use sharp `rounded-md` controls (Linear-like), not soft pill clusters
- Filtering resets to page 1; pagination scrolls back to the filter bar
- Single-category pages hide the chip row and keep pagination when needed

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run ci:archive`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

