### PR TITLE
Fix Vercel build: typed Routes on archive filter navigation

### DIFF
--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -32,6 +32,13 @@ function parsePage(value: string | null) {
 	return Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1
 }
 
+function hrefWithParams(pathname: string, params: URLSearchParams) {
+	const query = params.toString()
+	// Query-string URLs aren't in the typed Routes union; pathname is always a
+	// known archive route (/services, /expert-tips, etc.).
+	return (query ? `${pathname}?${query}` : pathname) as Route
+}
+
 function ArchiveCard({
 	item,
 	variant,
@@ -130,19 +137,12 @@ export function FilterableArchive({
 		[filtered, requestedPage, pageSize],
 	)
 
-	function hrefWithParams(params: URLSearchParams) {
-		const query = params.toString()
-		// Query-string URLs aren't in the typed Routes union; pathname is always a
-		// known archive route (/services, /expert-tips, etc.).
-		return (query ? `${pathname}?${query}` : pathname) as Route
-	}
-
 	useEffect(() => {
 		if (requestedPage === page) return
 		const params = new URLSearchParams(searchParams.toString())
 		if (page <= 1) params.delete("page")
 		else params.set("page", String(page))
-		router.replace(hrefWithParams(params), { scroll: false })
+		router.replace(hrefWithParams(pathname, params), { scroll: false })
 	}, [page, pathname, requestedPage, router, searchParams])
 
 	function updateParams(
@@ -163,7 +163,7 @@ export function FilterableArchive({
 		}
 
 		startTransition(() => {
-			router.replace(hrefWithParams(params), { scroll: false })
+			router.replace(hrefWithParams(pathname, params), { scroll: false })
 			if (options?.scrollToFilters) {
 				document
 					.getElementById("archive-filters")

--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -130,13 +130,19 @@ export function FilterableArchive({
 		[filtered, requestedPage, pageSize],
 	)
 
+	function hrefWithParams(params: URLSearchParams) {
+		const query = params.toString()
+		// Query-string URLs aren't in the typed Routes union; pathname is always a
+		// known archive route (/services, /expert-tips, etc.).
+		return (query ? `${pathname}?${query}` : pathname) as Route
+	}
+
 	useEffect(() => {
 		if (requestedPage === page) return
 		const params = new URLSearchParams(searchParams.toString())
 		if (page <= 1) params.delete("page")
 		else params.set("page", String(page))
-		const query = params.toString()
-		router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+		router.replace(hrefWithParams(params), { scroll: false })
 	}, [page, pathname, requestedPage, router, searchParams])
 
 	function updateParams(
@@ -156,11 +162,8 @@ export function FilterableArchive({
 			else params.set("page", String(next.page))
 		}
 
-		const query = params.toString()
 		startTransition(() => {
-			router.replace(query ? `${pathname}?${query}` : pathname, {
-				scroll: false,
-			})
+			router.replace(hrefWithParams(params), { scroll: false })
 			if (options?.scrollToFilters) {
 				document
 					.getElementById("archive-filters")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vercel failed typechecking after #25 because `router.replace(\`/services?category=...\`)` is not assignable to Next’s typed `Route` union.

## Fix

Cast archive URLs that include query strings to `Route` (same pattern as other dynamic navigations in the app). Lint + `tsc --noEmit` pass locally.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [ ] Confirm Vercel build on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

