### PR TITLE
Add related posts and services to content pages

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react"
 
 import { ContentPage } from "@/components/content-page"
 import { getCollection, getDocument, getPageOrPost } from "@/lib/content"
+import { getRelatedForPost, getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
 export async function generateStaticParams() {
@@ -40,6 +41,35 @@ export async function generateMetadata({
 	})
 }
 
+async function RelatedMarkdownPage({
+	document,
+	isPost,
+}: {
+	document: NonNullable<Awaited<ReturnType<typeof getPageOrPost>>>
+	isPost: boolean
+}) {
+	const related = isPost
+		? await getRelatedForPost(document)
+		: document.slug.startsWith("service-area/")
+			? await getRelatedForTopic(
+					{
+						label: document.title,
+						description: document.description,
+						keywords: [
+							document.slug.replaceAll("-", " "),
+							"plumbing",
+							"septic",
+							...(document.slug.includes("santa-cruz") ? ["santa cruz"] : []),
+						],
+						excludeSlugs: [document.slug],
+					},
+					{ posts: 3, services: 3 },
+				)
+			: undefined
+
+	return <ContentPage document={document} isPost={isPost} related={related} />
+}
+
 export default async function MarkdownPage({
 	params,
 }: {
@@ -56,7 +86,7 @@ export default async function MarkdownPage({
 
 	return (
 		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<ContentPage document={document} isPost={Boolean(post)} />
+			<RelatedMarkdownPage document={document} isPost={Boolean(post)} />
 		</Suspense>
 	)
 }

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
+import { getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
 const aliases: Record<string, string[]> = {
@@ -69,11 +70,22 @@ export default async function CategoryPage({
 	if (!posts.length) notFound()
 
 	const label = aliases[slug]?.[0] ?? posts[0]?.category ?? "Expert Tips"
+	const related = await getRelatedForTopic(
+		{
+			label,
+			description: `Practical ${label.toLowerCase()} from Wade's field experience.`,
+			categories: aliases[slug] ?? [label],
+			keywords: [label, slug.replaceAll("-", " ")],
+			excludeSlugs: posts.map((post) => post.slug),
+		},
+		{ posts: 3, services: 3 },
+	)
 
 	return (
 		<ArticleArchive
 			description={`Practical ${label.toLowerCase()} from Wade's field experience.`}
 			posts={posts}
+			related={related}
 			title={label}
 		/>
 	)

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -5,8 +5,10 @@ import { Suspense } from "react"
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { FilterableArchive } from "@/components/filterable-archive"
+import { RelatedContentSections } from "@/components/related-content"
 import { toArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
+import { getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
 const categories = {
@@ -103,6 +105,20 @@ export default async function ServiceCategoryPage({
 	const services = (await getCollection("services")).filter(
 		(service) => service.category === category.contentCategory,
 	)
+	const related = await getRelatedForTopic(
+		{
+			label: category.label,
+			description: category.description,
+			categories: [category.contentCategory],
+			keywords: [
+				category.label,
+				category.contentCategory,
+				slug.replaceAll("-", " "),
+			],
+			excludeSlugs: services.map((service) => service.slug),
+		},
+		{ posts: 3, services: 3 },
+	)
 
 	return (
 		<main id="main-content">
@@ -137,6 +153,11 @@ export default async function ServiceCategoryPage({
 					variant="service"
 				/>
 			</Suspense>
+			<RelatedContentSections
+				postsTitle="Related expert tips"
+				related={related}
+				servicesTitle="Related services"
+			/>
 			<ContactCta />
 		</main>
 	)

--- a/app/service-offerings/[slug]/page.tsx
+++ b/app/service-offerings/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react"
 
 import { ServiceLandingPage } from "@/components/service-landing-page"
 import { getCollection, getDocument } from "@/lib/content"
+import { getRelatedForService } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -30,6 +31,15 @@ export async function generateMetadata({
 	})
 }
 
+async function RelatedServicePage({
+	service,
+}: {
+	service: NonNullable<Awaited<ReturnType<typeof getDocument>>>
+}) {
+	const related = await getRelatedForService(service)
+	return <ServiceLandingPage related={related} service={service} />
+}
+
 export default async function ServiceOfferingPage({
 	params,
 }: {
@@ -42,7 +52,7 @@ export default async function ServiceOfferingPage({
 
 	return (
 		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<ServiceLandingPage service={service} />
+			<RelatedServicePage service={service} />
 		</Suspense>
 	)
 }

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
+import { getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
 export async function generateStaticParams() {
@@ -53,10 +54,22 @@ export default async function TagPage({
 		matched[0]?.tags?.find((tag) => taxonomySlug(tag) === slug) ??
 		slug.replaceAll("-", " ")
 
+	const related = await getRelatedForTopic(
+		{
+			label,
+			description: `Helpful Wade's articles filed under ${label}.`,
+			tags: [label],
+			keywords: [label, slug.replaceAll("-", " ")],
+			excludeSlugs: matched.map((post) => post.slug),
+		},
+		{ posts: 3, services: 3 },
+	)
+
 	return (
 		<ArticleArchive
 			description={`Helpful Wade's articles filed under ${label}.`}
 			posts={matched}
+			related={related}
 			title={label}
 		/>
 	)

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -3,17 +3,21 @@ import { Suspense } from "react"
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { FilterableArchive } from "@/components/filterable-archive"
+import { RelatedContentSections } from "@/components/related-content"
 import { toArchiveItem } from "@/lib/archive"
 import type { ContentDocument } from "@/lib/content"
+import type { RelatedContent } from "@/lib/related-content"
 
 export function ArticleArchive({
 	title,
 	description,
 	posts,
+	related,
 }: {
 	title: string
 	description: string
 	posts: ContentDocument[]
+	related?: RelatedContent
 }) {
 	const items = posts.map((post) =>
 		toArchiveItem(post, `/${post.slug}`, post.category ?? "Expert Tips"),
@@ -46,6 +50,13 @@ export function ArticleArchive({
 					variant="tip"
 				/>
 			</Suspense>
+			{related ? (
+				<RelatedContentSections
+					postsTitle="More related guides"
+					related={related}
+					servicesTitle="Related services"
+				/>
+			) : null}
 			<ContactCta title="Need professional help?" />
 		</main>
 	)

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -1,6 +1,7 @@
 import type { Route } from "next"
 
 import type { ContentDocument } from "@/lib/content"
+import type { RelatedContent } from "@/lib/related-content"
 import { articleJsonLd, breadcrumbJsonLd, webPageJsonLd } from "@/lib/seo"
 
 import { ContactCta } from "@/components/contact-cta"
@@ -8,13 +9,16 @@ import { ContentGallery } from "@/components/content-gallery"
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
 import { MarkdownContent } from "@/components/markdown-content"
+import { RelatedContentSections } from "@/components/related-content"
 
 export function ContentPage({
 	document,
 	isPost = false,
+	related,
 }: {
 	document: ContentDocument
 	isPost?: boolean
+	related?: RelatedContent
 }) {
 	const breadcrumbs = [
 		{ name: "Home", path: "/" },
@@ -71,6 +75,7 @@ export function ContentPage({
 					/>
 				</aside>
 			</article>
+			{related ? <RelatedContentSections related={related} /> : null}
 			<ContactCta />
 			<JsonLd
 				data={[

--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -32,6 +32,13 @@ function parsePage(value: string | null) {
 	return Number.isFinite(page) && page >= 1 ? Math.floor(page) : 1
 }
 
+function hrefWithParams(pathname: string, params: URLSearchParams) {
+	const query = params.toString()
+	// Query-string URLs aren't in the typed Routes union; pathname is always a
+	// known archive route (/services, /expert-tips, etc.).
+	return (query ? `${pathname}?${query}` : pathname) as Route
+}
+
 function ArchiveCard({
 	item,
 	variant,
@@ -135,8 +142,7 @@ export function FilterableArchive({
 		const params = new URLSearchParams(searchParams.toString())
 		if (page <= 1) params.delete("page")
 		else params.set("page", String(page))
-		const query = params.toString()
-		router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false })
+		router.replace(hrefWithParams(pathname, params), { scroll: false })
 	}, [page, pathname, requestedPage, router, searchParams])
 
 	function updateParams(
@@ -156,11 +162,8 @@ export function FilterableArchive({
 			else params.set("page", String(next.page))
 		}
 
-		const query = params.toString()
 		startTransition(() => {
-			router.replace(query ? `${pathname}?${query}` : pathname, {
-				scroll: false,
-			})
+			router.replace(hrefWithParams(pathname, params), { scroll: false })
 			if (options?.scrollToFilters) {
 				document
 					.getElementById("archive-filters")

--- a/components/related-content.tsx
+++ b/components/related-content.tsx
@@ -1,0 +1,145 @@
+import type { Route } from "next"
+import Image from "next/image"
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+
+import type { ArchiveItem } from "@/lib/archive"
+import type { RelatedContent } from "@/lib/related-content"
+import { getServiceImage } from "@/lib/service-images"
+import { Badge } from "@/components/ui/badge"
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card"
+
+function RelatedCard({
+	item,
+	variant,
+}: {
+	item: ArchiveItem
+	variant: "service" | "tip"
+}) {
+	const image =
+		variant === "service"
+			? getServiceImage(item.category, item.image)
+			: (item.image ?? "/images/work/precision-valve-installation.webp")
+
+	return (
+		<Card className="group hover:border-primary/35 flex h-full flex-col overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5">
+			<Link
+				aria-label={
+					variant === "service" ? `View ${item.title}` : `Read ${item.title}`
+				}
+				className="bg-muted relative block aspect-[16/9] overflow-hidden"
+				href={item.href as Route}
+				prefetch={false}
+				tabIndex={-1}
+			>
+				<Image
+					alt=""
+					className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+					fill
+					quality={55}
+					sizes="(min-width: 1024px) 22vw, (min-width: 768px) 33vw, 100vw"
+					src={image}
+				/>
+			</Link>
+			<CardHeader className="space-y-2">
+				<Badge className="w-fit" tone="muted">
+					{item.category}
+				</Badge>
+				<CardTitle className="group-hover:text-primary text-lg transition-colors">
+					<Link href={item.href as Route} prefetch={false}>
+						{item.title}
+					</Link>
+				</CardTitle>
+				<CardDescription className="line-clamp-2">
+					{item.description}
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="mt-auto">
+				<Link
+					className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
+					href={item.href as Route}
+					prefetch={false}
+				>
+					{variant === "service" ? "View service" : "Read guide"}
+					<ArrowRight className="size-4 transition-transform group-hover:translate-x-1" />
+				</Link>
+			</CardContent>
+		</Card>
+	)
+}
+
+function RelatedGroup({
+	title,
+	items,
+	variant,
+	viewAllHref,
+	viewAllLabel,
+}: {
+	title: string
+	items: ArchiveItem[]
+	variant: "service" | "tip"
+	viewAllHref: Route
+	viewAllLabel: string
+}) {
+	if (!items.length) return null
+
+	return (
+		<div>
+			<div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+				<h2 className="type-title text-2xl sm:text-3xl">{title}</h2>
+				<Link
+					className="text-primary inline-flex items-center gap-2 text-sm font-extrabold"
+					href={viewAllHref}
+					prefetch={false}
+				>
+					{viewAllLabel}
+					<ArrowRight className="size-4" />
+				</Link>
+			</div>
+			<div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+				{items.map((item) => (
+					<RelatedCard item={item} key={item.slug} variant={variant} />
+				))}
+			</div>
+		</div>
+	)
+}
+
+export function RelatedContentSections({
+	related,
+	servicesTitle = "Related services",
+	postsTitle = "Related guides",
+}: {
+	related: RelatedContent
+	servicesTitle?: string
+	postsTitle?: string
+}) {
+	if (!related.services.length && !related.posts.length) return null
+
+	return (
+		<section className="border-border bg-secondary/35 border-y">
+			<div className="container-shell section-y space-y-14">
+				<RelatedGroup
+					items={related.services}
+					title={servicesTitle}
+					variant="service"
+					viewAllHref={"/services" as Route}
+					viewAllLabel="Browse all services"
+				/>
+				<RelatedGroup
+					items={related.posts}
+					title={postsTitle}
+					variant="tip"
+					viewAllHref={"/expert-tips" as Route}
+					viewAllLabel="Browse all guides"
+				/>
+			</div>
+		</section>
+	)
+}

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -4,13 +4,21 @@ import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
 import { MarkdownContent } from "@/components/markdown-content"
+import { RelatedContentSections } from "@/components/related-content"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { ContentDocument } from "@/lib/content"
+import type { RelatedContent } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
 import { breadcrumbJsonLd } from "@/lib/seo"
 import { siteConfig } from "@/lib/site"
 
-export function ServiceLandingPage({ service }: { service: ContentDocument }) {
+export function ServiceLandingPage({
+	service,
+	related,
+}: {
+	service: ContentDocument
+	related?: RelatedContent
+}) {
 	const image = getServiceImage(service.category, service.image)
 	const schema = {
 		"@context": "https://schema.org",
@@ -94,6 +102,13 @@ export function ServiceLandingPage({ service }: { service: ContentDocument }) {
 				</aside>
 			</section>
 
+			{related ? (
+				<RelatedContentSections
+					postsTitle="Related expert tips"
+					related={related}
+					servicesTitle="Related services"
+				/>
+			) : null}
 			<ContactCta
 				description={`Contact us today for professional ${service.title.toLowerCase()} service.`}
 			/>

--- a/lib/related-content.ts
+++ b/lib/related-content.ts
@@ -1,0 +1,119 @@
+import "server-only"
+
+import { toArchiveItem, type ArchiveItem } from "@/lib/archive"
+import { getCollection, type ContentDocument } from "@/lib/content"
+import { rankDocuments, seedFromDocument, tokenize } from "@/lib/related-score"
+
+export type RelatedContent = {
+	posts: ArchiveItem[]
+	services: ArchiveItem[]
+}
+
+function toPostItem(post: ContentDocument): ArchiveItem {
+	return toArchiveItem(post, `/${post.slug}`, post.category ?? "Expert Tips")
+}
+
+function toServiceItem(service: ContentDocument): ArchiveItem {
+	return toArchiveItem(
+		service,
+		`/service-offerings/${service.slug}`,
+		service.category ?? "Plumbing",
+	)
+}
+
+export async function getRelatedForPost(
+	post: ContentDocument,
+	limits: { posts?: number; services?: number } = {},
+): Promise<RelatedContent> {
+	const [posts, services] = await Promise.all([
+		getCollection("posts"),
+		getCollection("services"),
+	])
+	const seed = seedFromDocument(post)
+	const exclude = new Set([post.slug])
+
+	return {
+		posts: rankDocuments(seed, posts, "post", limits.posts ?? 3, exclude).map(
+			toPostItem,
+		),
+		services: rankDocuments(
+			seed,
+			services,
+			"service",
+			limits.services ?? 3,
+			exclude,
+		).map(toServiceItem),
+	}
+}
+
+export async function getRelatedForService(
+	service: ContentDocument,
+	limits: { posts?: number; services?: number } = {},
+): Promise<RelatedContent> {
+	const [posts, services] = await Promise.all([
+		getCollection("posts"),
+		getCollection("services"),
+	])
+	const seed = seedFromDocument(service)
+	const exclude = new Set([service.slug])
+
+	return {
+		posts: rankDocuments(seed, posts, "post", limits.posts ?? 3, exclude).map(
+			toPostItem,
+		),
+		services: rankDocuments(
+			seed,
+			services,
+			"service",
+			limits.services ?? 3,
+			exclude,
+		).map(toServiceItem),
+	}
+}
+
+export async function getRelatedForTopic(
+	topic: {
+		label: string
+		description?: string
+		categories?: string[]
+		tags?: string[]
+		keywords?: string[]
+		excludeSlugs?: string[]
+	},
+	limits: { posts?: number; services?: number } = {},
+): Promise<RelatedContent> {
+	const [posts, services] = await Promise.all([
+		getCollection("posts"),
+		getCollection("services"),
+	])
+
+	const synthetic: ContentDocument = {
+		slug: `__topic__${topic.label}`,
+		title: topic.label,
+		description: topic.description ?? topic.label,
+		content: [topic.label, ...(topic.keywords ?? [])].join(" "),
+		category: topic.categories?.[0],
+		tags: [...(topic.tags ?? []), ...(topic.keywords ?? [])],
+	}
+	const seed = seedFromDocument(synthetic)
+	const exclude = new Set(topic.excludeSlugs ?? [])
+
+	if (topic.categories?.length) {
+		for (const category of topic.categories) {
+			for (const token of tokenize(category)) seed.tokens.add(token)
+		}
+	}
+
+	return {
+		posts: rankDocuments(seed, posts, "post", limits.posts ?? 3, exclude).map(
+			toPostItem,
+		),
+		services: rankDocuments(
+			seed,
+			services,
+			"service",
+			limits.services ?? 3,
+			exclude,
+		).map(toServiceItem),
+	}
+}

--- a/lib/related-score.ts
+++ b/lib/related-score.ts
@@ -1,0 +1,218 @@
+export type RelatedSeedDocument = {
+	slug: string
+	title: string
+	description: string
+	content: string
+	category?: string
+	tags?: string[]
+}
+
+const STOP_WORDS = new Set([
+	"a",
+	"an",
+	"and",
+	"are",
+	"as",
+	"at",
+	"be",
+	"by",
+	"ca",
+	"county",
+	"for",
+	"from",
+	"guide",
+	"guides",
+	"how",
+	"in",
+	"into",
+	"is",
+	"it",
+	"local",
+	"of",
+	"on",
+	"or",
+	"our",
+	"santa",
+	"service",
+	"services",
+	"the",
+	"to",
+	"with",
+	"your",
+	"you",
+	"cruz",
+])
+
+const TOPIC_BRIDGES: Array<{ pattern: RegExp; boost: string[] }> = [
+	{
+		pattern: /\bseptic|leach|drain.?field|pumping|engineered septic\b/i,
+		boost: ["septic", "tank", "leach", "drainfield", "pumping", "engineered"],
+	},
+	{
+		pattern: /\bhydro.?jet|jetting|clog|drain cleaning|slow drain\b/i,
+		boost: ["hydro", "jet", "drain", "clog", "clear"],
+	},
+	{
+		pattern: /\bleak|frozen.?pipe|pipe repair|water line\b/i,
+		boost: ["leak", "pipe", "water-line", "valve"],
+	},
+	{
+		pattern: /\bwater.?heater|tankless\b/i,
+		boost: ["water-heater", "tankless", "heater"],
+	},
+	{
+		pattern: /\btoilet|flange\b/i,
+		boost: ["toilet", "fixture"],
+	},
+	{
+		pattern: /\bshower|faucet|fixture\b/i,
+		boost: ["shower", "faucet", "fixture"],
+	},
+	{
+		pattern: /\bsoftener|filtration|hard.?water|filter\b/i,
+		boost: ["softener", "filtration", "filter", "water"],
+	},
+	{
+		pattern: /\bsewer|trenchless|camera|video.?inspect|smoke\b/i,
+		boost: ["sewer", "trenchless", "camera", "video", "smoke", "main-line"],
+	},
+	{
+		pattern: /\bcommercial|grease|backflow\b/i,
+		boost: ["commercial", "grease", "backflow"],
+	},
+]
+
+export function tokenize(value: string) {
+	return new Set(
+		value
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, " ")
+			.split(/[\s-]+/)
+			.filter((token) => token.length > 2 && !STOP_WORDS.has(token)),
+	)
+}
+
+function bridgeTokens(haystack: string) {
+	const tokens = new Set<string>()
+	for (const bridge of TOPIC_BRIDGES) {
+		if (bridge.pattern.test(haystack)) {
+			for (const word of bridge.boost) tokens.add(word)
+		}
+	}
+	return tokens
+}
+
+function overlapScore(a: Set<string>, b: Set<string>, weight: number) {
+	let score = 0
+	for (const token of a) {
+		if (b.has(token)) score += weight
+	}
+	return score
+}
+
+export function seedFromDocument(document: RelatedSeedDocument) {
+	const haystack = [
+		document.title,
+		document.description,
+		document.category ?? "",
+		...(document.tags ?? []),
+		document.slug.replaceAll("-", " "),
+		document.content.slice(0, 1200),
+	].join(" ")
+
+	return {
+		slug: document.slug,
+		category: document.category ?? "",
+		tags: new Set((document.tags ?? []).map((tag) => tag.toLowerCase())),
+		tokens: tokenize(haystack),
+		bridges: bridgeTokens(haystack),
+	}
+}
+
+export function scoreCandidate(
+	seed: ReturnType<typeof seedFromDocument>,
+	candidate: RelatedSeedDocument,
+	kind: "post" | "service",
+) {
+	if (candidate.slug === seed.slug) return -Infinity
+
+	const candidateHay = [
+		candidate.title,
+		candidate.description,
+		candidate.category ?? "",
+		...(candidate.tags ?? []),
+		candidate.slug.replaceAll("-", " "),
+	].join(" ")
+	const tokens = tokenize(candidateHay)
+	const bridges = bridgeTokens(candidateHay)
+
+	let score = 0
+
+	if (
+		seed.category &&
+		candidate.category &&
+		seed.category.toLowerCase() === candidate.category.toLowerCase()
+	) {
+		score += kind === "post" ? 8 : 6
+	}
+
+	if (kind === "service" && seed.category) {
+		const seedCat = seed.category.toLowerCase()
+		const serviceCat = (candidate.category ?? "").toLowerCase()
+		if (seedCat.includes("septic") && serviceCat === "septic") score += 7
+		if (
+			(seedCat.includes("plumbing") || seedCat.includes("diy")) &&
+			serviceCat === "plumbing"
+		) {
+			score += 5
+		}
+		if (seedCat.includes("commercial") && serviceCat === "commercial") {
+			score += 6
+		}
+	}
+
+	if (kind === "post" && seed.category) {
+		const serviceCat = seed.category.toLowerCase()
+		const postCat = (candidate.category ?? "").toLowerCase()
+		if (serviceCat === "septic" && postCat.includes("septic")) score += 7
+		if (serviceCat === "plumbing" && postCat.includes("plumbing")) score += 5
+		if (serviceCat === "commercial" && postCat.includes("commercial")) {
+			score += 5
+		}
+	}
+
+	for (const tag of seed.tags) {
+		if ((candidate.tags ?? []).some((item) => item.toLowerCase() === tag)) {
+			score += 4
+		}
+	}
+
+	score += overlapScore(seed.tokens, tokens, 2)
+	score += overlapScore(seed.bridges, tokens, 3)
+	score += overlapScore(seed.bridges, bridges, 2)
+	score += overlapScore(seed.tokens, bridges, 2)
+
+	return score
+}
+
+export function rankDocuments(
+	seed: ReturnType<typeof seedFromDocument>,
+	candidates: RelatedSeedDocument[],
+	kind: "post" | "service",
+	limit: number,
+	excludeSlugs: Set<string> = new Set(),
+) {
+	return candidates
+		.filter((candidate) => !excludeSlugs.has(candidate.slug))
+		.map((candidate) => ({
+			candidate,
+			score: scoreCandidate(seed, candidate, kind),
+		}))
+		.filter((row) => row.score > 0)
+		.sort(
+			(a, b) =>
+				b.score - a.score || a.candidate.title.localeCompare(b.candidate.title),
+		)
+		.slice(0, limit)
+		.map((row) => row.candidate)
+}

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
 		"ci:self-hosted-policy": "node scripts/ci/assert-self-hosted-only.mjs",
 		"ci:search": "npx --yes tsx scripts/ci/test-search.ts",
 		"ci:archive": "npx --yes tsx scripts/ci/test-archive.ts",
+		"ci:related": "npx --yes tsx scripts/ci/test-related-content.ts",
 		"migrate:wayback": "python3 -u scripts/migrate-from-wayback.py",
 		"migrate:wordpress": "python3 -u scripts/migrate-from-wordpress-csv.py",
 		"migrate:wordpress-images": "python3 -u scripts/migrate-wordpress-images.py",
-		"check": "npm run lint && npm run typecheck && npm run format:check && npm run ci:search && npm run ci:archive && npm run build"
+		"check": "npm run lint && npm run typecheck && npm run format:check && npm run ci:search && npm run ci:archive && npm run ci:related && npm run build"
 	},
 	"dependencies": {
 		"@radix-ui/react-accordion": "1.2.20",

--- a/scripts/ci/test-related-content.ts
+++ b/scripts/ci/test-related-content.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+
+import {
+	rankDocuments,
+	seedFromDocument,
+	type RelatedSeedDocument,
+} from "../../lib/related-score"
+
+const tip: RelatedSeedDocument = {
+	slug: "the-benefits-of-hydro-jetting",
+	title: "The Benefits of Hydro Jetting",
+	description: "Clear stubborn drain clogs with high-pressure jetting.",
+	content: "Hydro jetting clears grease and roots from sewer lines.",
+	category: "Plumbing Tips",
+	tags: ["hydro jetting", "drain cleaning"],
+}
+
+const posts: RelatedSeedDocument[] = [
+	tip,
+	{
+		slug: "slow-drains-solutions-santa-cruz",
+		title: "Slow Drain Solutions",
+		description: "What to do about slow drains.",
+		content: "Slow drains often need professional cleaning.",
+		category: "Plumbing Tips",
+		tags: ["drain cleaning"],
+	},
+	{
+		slug: "septic-pumping-essentials-santa-cruz",
+		title: "Septic Pumping Essentials",
+		description: "When to pump your septic tank.",
+		content: "Pump septic tanks on a regular schedule.",
+		category: "Septic Maintenance",
+		tags: ["septic"],
+	},
+]
+
+const services: RelatedSeedDocument[] = [
+	{
+		slug: "hydro-jetting",
+		title: "Hydro Jetting",
+		description: "High-pressure drain clearing.",
+		content: "Hydro jetting for clogged drains and sewer lines.",
+		category: "Plumbing",
+	},
+	{
+		slug: "drain-cleaning",
+		title: "Drain Cleaning",
+		description: "Professional drain cleaning.",
+		content: "Clear household drains.",
+		category: "Plumbing",
+	},
+	{
+		slug: "septic-tank-cleaning-and-pumping",
+		title: "Septic Tank Cleaning and Pumping",
+		description: "Pump and clean septic tanks.",
+		content: "Routine septic pumping.",
+		category: "Septic",
+	},
+]
+
+const seed = seedFromDocument(tip)
+const relatedServices = rankDocuments(seed, services, "service", 3)
+const relatedPosts = rankDocuments(seed, posts, "post", 3, new Set([tip.slug]))
+
+assert.ok(relatedServices.length > 0)
+assert.ok(
+	relatedServices.some(
+		(service) =>
+			service.slug.includes("hydro") || service.slug.includes("drain"),
+	),
+	`expected drain/hydro service, got ${relatedServices.map((item) => item.slug).join(", ")}`,
+)
+assert.ok(relatedPosts.every((post) => post.slug !== tip.slug))
+assert.equal(relatedPosts[0]?.slug, "slow-drains-solutions-santa-cruz")
+
+const septicSeed = seedFromDocument(services[2]!)
+const septicTips = rankDocuments(septicSeed, posts, "post", 3)
+assert.ok(
+	septicTips.some((post) => post.slug.includes("septic")),
+	`expected septic tip, got ${septicTips.map((item) => item.slug).join(", ")}`,
+)
+
+console.log("related content ok")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds topic-aware **Related services** and **Related guides** sections to the bottoms of content pages so readers can keep moving through useful material.

## Where it shows

- Expert tip posts
- Service offering pages
- Service-area pages
- Category archives (`/category/...`)
- Tag archives (`/tag/...`)
- Service category pages (`/service-category/...`)

## How relatedness works

Ranking uses category/tag matches plus keyword bridges (e.g. hydro-jetting tips → hydro-jetting / drain services, septic posts → septic services). Current page items are excluded from results.

## Also included

- Fixes the typedRoutes `router.replace(?query)` build failure from #25 so Vercel can typecheck

## Testing

- `npm run lint`
- `npm run typecheck`
- `npm run ci:related`
- `npm run ci:archive`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

