### PR TITLE
Add descriptive alt text to all images

### DIFF
--- a/components/content-gallery.tsx
+++ b/components/content-gallery.tsx
@@ -12,7 +12,11 @@ export function ContentGallery({ images }: { images: ContentImage[] }) {
 				>
 					<div className="bg-muted relative aspect-[4/3] overflow-hidden rounded-lg">
 						<Image
-							alt={image.alt}
+							alt={
+								image.alt?.trim() ||
+								image.caption?.trim() ||
+								"Wade's Plumbing & Septic project photo"
+							}
 							className="object-cover"
 							fill
 							quality={75}

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -28,7 +28,7 @@ export function ContentHero({
 			{image ? (
 				<>
 					<Image
-						alt={imageAlt ?? ""}
+						alt={imageAlt?.trim() || title}
 						className="object-cover opacity-40"
 						fill
 						priority

--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -63,7 +63,7 @@ function ArchiveCard({
 				tabIndex={-1}
 			>
 				<Image
-					alt=""
+					alt={item.imageAlt ?? `${item.title} — Wade's Plumbing & Septic`}
 					className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
 					fill
 					quality={60}

--- a/components/global-search.tsx
+++ b/components/global-search.tsx
@@ -134,7 +134,7 @@ function ResultCard({
 				{hit.image ? (
 					<Image
 						src={hit.image}
-						alt=""
+						alt={hit.title}
 						fill
 						className="object-cover transition-transform duration-150 group-hover:scale-[1.03]"
 						sizes="120px"

--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -4,13 +4,7 @@ import Link from "next/link"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
-function MarkdownImage({
-	src,
-	alt,
-}: {
-	src?: string
-	alt?: string
-}) {
+function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
 	if (!src) return null
 
 	const isLocal = src.startsWith("/")
@@ -31,7 +25,7 @@ function MarkdownImage({
 	return (
 		<figure className="bg-muted my-8 overflow-hidden rounded-lg">
 			<Image
-				alt={alt ?? ""}
+				alt={alt?.trim() || "Wade's Plumbing & Septic project photo"}
 				className="h-auto w-full object-cover"
 				height={900}
 				sizes="(min-width: 1024px) 48rem, 100vw"
@@ -64,7 +58,10 @@ export function MarkdownContent({ content }: { content: string }) {
 						)
 					},
 					img: ({ src, alt }) => (
-						<MarkdownImage alt={alt} src={typeof src === "string" ? src : undefined} />
+						<MarkdownImage
+							alt={alt}
+							src={typeof src === "string" ? src : undefined}
+						/>
 					),
 				}}
 			>

--- a/components/service-card.tsx
+++ b/components/service-card.tsx
@@ -28,7 +28,9 @@ export function ServiceCard({ service }: { service: ContentDocument }) {
 				tabIndex={-1}
 			>
 				<Image
-					alt=""
+					alt={
+						service.imageAlt ?? `${service.title} — Wade's Plumbing & Septic`
+					}
 					className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
 					fill
 					quality={60}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -59,7 +59,7 @@ export function SiteFooter() {
 							prefetch
 						>
 							<Image
-								alt=""
+								alt="Wade's Plumbing & Septic logo"
 								className="size-11 shrink-0 rounded-md sm:size-12"
 								height={48}
 								src="/images/brand/wades-mark-sm.webp"

--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -196,7 +196,7 @@ export function SiteHeaderNav() {
 						<SheetHeader className="shadow-[inset_0_-1px_0_0_var(--border)]">
 							<div className="flex items-center gap-3">
 								<Image
-									alt=""
+									alt="Wade's Plumbing & Septic logo"
 									className="size-10 rounded-md"
 									height={40}
 									src="/images/brand/wades-mark-sm.webp"

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -28,7 +28,7 @@ export function SiteHeader() {
 					prefetch
 				>
 					<Image
-						alt=""
+						alt="Wade's Plumbing & Septic logo"
 						className="size-10 shrink-0 rounded-md sm:size-11"
 						height={44}
 						src="/images/brand/wades-mark-sm.webp"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fills empty `alt` attributes across the UI so images are accessible and better for SEO.

### Updates
- Brand logos (header, mobile nav, footer): `Wade's Plumbing & Septic logo`
- Service cards / archive cards: `imageAlt` or title-based fallback
- Global search result thumbnails: hit title
- Content hero: `imageAlt` or page title
- Markdown images: meaningful fallback when alt is missing
- Content gallery: alt → caption → project photo fallback

## Validation
- `npm run lint`
- `npm run typecheck`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

