### PR TITLE
Fix blank white service areas map

### DIFF
--- a/components/service-areas-map.tsx
+++ b/components/service-areas-map.tsx
@@ -28,6 +28,12 @@ const BRAND = {
 	ink: "#101214",
 } as const
 
+/** OpenFreeMap — reliable free vector basemap (Carto tiles often leave a blank white canvas). */
+const mapStyles = {
+	light: "https://tiles.openfreemap.org/styles/positron",
+	dark: "https://tiles.openfreemap.org/styles/dark",
+} as const
+
 const fillPaint = {
 	"fill-color": [
 		"match",
@@ -42,12 +48,12 @@ const fillPaint = {
 		"match",
 		["get", "tier"],
 		"primary",
-		0.42,
+		0.45,
 		"secondary",
-		0.28,
-		0.35,
+		0.32,
+		0.4,
 	],
-} as FillLayerSpecification["paint"]
+} satisfies FillLayerSpecification["paint"]
 
 const linePaint = {
 	"line-color": [
@@ -60,23 +66,29 @@ const linePaint = {
 		BRAND.primary,
 	],
 	"line-width": 2.25,
-	"line-opacity": 0.92,
-} as LineLayerSpecification["paint"]
+	"line-opacity": 0.95,
+} satisfies LineLayerSpecification["paint"]
 
 const fillHoverPaint = {
-	"fill-opacity": 0.58,
-} as FillLayerSpecification["paint"]
+	"fill-opacity": 0.62,
+} satisfies FillLayerSpecification["paint"]
 
 function FitServiceAreaBounds() {
 	const { map, isLoaded } = useMap()
 
 	useEffect(() => {
 		if (!map || !isLoaded) return
-		map.fitBounds(serviceAreaMapBounds, {
-			padding: { top: 56, bottom: 56, left: 48, right: 48 },
-			duration: 0,
-			maxZoom: 10,
+
+		const frame = requestAnimationFrame(() => {
+			map.resize()
+			map.fitBounds(serviceAreaMapBounds, {
+				padding: { top: 56, bottom: 56, left: 48, right: 48 },
+				duration: 0,
+				maxZoom: 10,
+			})
 		})
+
+		return () => cancelAnimationFrame(frame)
 	}, [map, isLoaded])
 
 	return null
@@ -91,11 +103,12 @@ export function ServiceAreasMap() {
 
 	return (
 		<div className="space-y-3">
-			<div className="border-border bg-card relative h-[min(70vh,36rem)] min-h-[22rem] overflow-hidden rounded-lg border shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
+			<div className="border-border bg-muted/40 relative h-[min(70vh,36rem)] min-h-[22rem] w-full overflow-hidden rounded-lg border shadow-[inset_0_0_0_1px_rgba(0,0,0,0.02)]">
 				<Map
 					center={serviceAreaMapCenter}
-					className="absolute inset-0 size-full"
+					className="h-full w-full"
 					theme="light"
+					styles={mapStyles}
 					zoom={serviceAreaMapZoom}
 					fadeDuration={0}
 				>

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -318,7 +318,26 @@ const Map = forwardRef<MapRef, MapProps>(function Map(
     map.on("move", handleMove);
     setMapInstance(map);
 
+    // MapLibre sizes the canvas from the container at init. If the container
+    // is still 0×0 (common with absolute/flex layouts), the map stays blank
+    // white until resize is called once real dimensions exist.
+    const container = containerRef.current;
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            if (!container.offsetWidth || !container.offsetHeight) return;
+            map.resize();
+          });
+    resizeObserver?.observe(container);
+    requestAnimationFrame(() => {
+      if (container.offsetWidth && container.offsetHeight) {
+        map.resize();
+      }
+    });
+
     return () => {
+      resizeObserver?.disconnect();
       map.off("load", loadHandler);
       map.off("style.load", styleLoadHandler);
       map.off("move", handleMove);
@@ -1373,12 +1392,15 @@ function MapGeoJSON<
   // Add source on mount.
   useEffect(() => {
     if (!isLoaded || !map) return;
+    if (!map.isStyleLoaded()) return;
 
-    map.addSource(sourceId, {
-      type: "geojson",
-      data,
-      ...(promoteId ? { promoteId } : {}),
-    });
+    if (!map.getSource(sourceId)) {
+      map.addSource(sourceId, {
+        type: "geojson",
+        data,
+        ...(promoteId ? { promoteId } : {}),
+      });
+    }
 
     return () => {
       try {

--- a/components/ui/map.tsx
+++ b/components/ui/map.tsx
@@ -1392,7 +1392,6 @@ function MapGeoJSON<
   // Add source on mount.
   useEffect(() => {
     if (!isLoaded || !map) return;
-    if (!map.isStyleLoaded()) return;
 
     if (!map.getSource(sourceId)) {
       map.addSource(sourceId, {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The service areas map was rendering as a blank white box after the GeoJSON coverage update.

### Causes
1. MapLibre initialized while the container could still be **0×0** (absolute fill layout) and never called `resize()`, so the canvas stayed empty
2. Default Carto basemap tiles often fail to paint, leaving only the white Positron background — with layers not visibly attached it looked fully blank

### Fixes
- Add a `ResizeObserver` + rAF `map.resize()` in the shared Map component when the container gets real dimensions
- Service areas map uses a normal `h-full w-full` container (no absolute positioning)
- Switch basemap to **OpenFreeMap** positron/dark styles
- Fit bounds after resize so brand GeoJSON coverage is in view

## Validation
- `npx tsc --noEmit`
- `npx eslint` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

