### PR TITLE
Reorder nav: Home, Services, Service Area, Expert Tips, Company

### DIFF
--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/sheet"
 import {
 	companyNavLinks,
-	primaryNavLinks,
+	midNavLinks,
 	serviceNavLinks,
 	type NavLink,
 } from "@/lib/navigation"
@@ -89,7 +89,35 @@ export function SiteHeaderNav() {
 				aria-label="Primary navigation"
 			>
 				<NavigationMenuList>
-					{primaryNavLinks.map((item) => (
+					<NavigationMenuItem>
+						<NavigationMenuLink asChild>
+							<Link
+								className={cn(
+									navigationMenuTriggerStyle(),
+									"hover:text-primary-bright focus:text-primary-bright data-[active]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[active]:bg-transparent",
+								)}
+								href={"/" as Route}
+								prefetch
+							>
+								Home
+							</Link>
+						</NavigationMenuLink>
+					</NavigationMenuItem>
+
+					<NavigationMenuItem>
+						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
+							Services
+						</NavigationMenuTrigger>
+						<NavigationMenuContent>
+							<ul className="grid w-[22rem] gap-1 p-3 md:w-[28rem] md:grid-cols-2">
+								{serviceNavLinks.map((item) => (
+									<ListItem key={item.href} {...item} />
+								))}
+							</ul>
+						</NavigationMenuContent>
+					</NavigationMenuItem>
+
+					{midNavLinks.map((item) => (
 						<NavigationMenuItem key={item.href}>
 							<NavigationMenuLink asChild>
 								<Link
@@ -105,19 +133,6 @@ export function SiteHeaderNav() {
 							</NavigationMenuLink>
 						</NavigationMenuItem>
 					))}
-
-					<NavigationMenuItem>
-						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
-							Services
-						</NavigationMenuTrigger>
-						<NavigationMenuContent>
-							<ul className="grid w-[22rem] gap-1 p-3 md:w-[28rem] md:grid-cols-2">
-								{serviceNavLinks.map((item) => (
-									<ListItem key={item.href} {...item} />
-								))}
-							</ul>
-						</NavigationMenuContent>
-					</NavigationMenuItem>
 
 					<NavigationMenuItem>
 						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
@@ -213,12 +228,7 @@ export function SiteHeaderNav() {
 							className="flex-1 overflow-y-auto px-2 py-3"
 							aria-label="Mobile navigation"
 						>
-							<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
-								Explore
-							</p>
-							{primaryNavLinks.map((item) => (
-								<MobileNavLink key={item.href} {...item} />
-							))}
+							<MobileNavLink href="/" label="Home" />
 
 							<Separator className="my-3" />
 
@@ -226,6 +236,12 @@ export function SiteHeaderNav() {
 								Services
 							</p>
 							{serviceNavLinks.map((item) => (
+								<MobileNavLink key={item.href} {...item} />
+							))}
+
+							<Separator className="my-3" />
+
+							{midNavLinks.map((item) => (
 								<MobileNavLink key={item.href} {...item} />
 							))}
 

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -56,8 +56,13 @@ export const companyNavLinks: NavLink[] = [
 	},
 ]
 
+/** Top-level links shown after Services and before Company. */
+export const midNavLinks: NavLink[] = [
+	{ href: "/service-areas", label: "Service Area" },
+	{ href: "/expert-tips", label: "Expert Tips" },
+]
+
 export const primaryNavLinks: NavLink[] = [
 	{ href: "/", label: "Home" },
-	{ href: "/expert-tips", label: "Expert Tips" },
-	{ href: "/service-areas", label: "Service Areas" },
+	...midNavLinks,
 ]

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -20,15 +20,14 @@ export const siteConfig = {
 export const primaryNavigation = [
 	{ href: "/", label: "Home" },
 	{ href: "/services", label: "Services" },
+	{ href: "/service-areas", label: "Service Area" },
 	{ href: "/expert-tips", label: "Expert Tips" },
-	{ href: "/service-areas", label: "Service Areas" },
 	{ href: "/about-us", label: "About Us" },
 ] as const
 
 export const companyNavigation = [
 	{ href: "/about-us", label: "About Us" },
 	{ href: "/testimonials", label: "Customer Reviews" },
-	{ href: "/service-areas", label: "Service Areas" },
 	{ href: "/faq", label: "FAQ" },
 	{ href: "/financing", label: "Financing" },
 	{ href: "/warranties", label: "Warranties" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates primary navigation order to:

**Home → Services → Service Area → Expert Tips → Company**

### Changes
- Desktop header renders links/dropdowns in that order
- Mobile sheet matches the same sequence
- `primaryNavigation` in site config updated for search indexing
- Removed duplicate Service Areas link from the footer Company column (it lives in primary nav now)

## Validation
- `npx tsc --noEmit`
- `npx eslint` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

