### PR TITLE
Full-width mega menus for Services & Company nav

### DIFF
--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -3,7 +3,24 @@
 import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import { Menu, Phone, Search } from "lucide-react"
+import {
+	ArrowRight,
+	BadgeCheck,
+	Briefcase,
+	Building2,
+	CircleHelp,
+	Droplets,
+	Menu,
+	Phone,
+	Search,
+	ShieldCheck,
+	Siren,
+	Star,
+	Users,
+	Wallet,
+	Wrench,
+	type LucideIcon,
+} from "lucide-react"
 
 import { Button, buttonVariants } from "@/components/ui/button"
 import { openGlobalSearch } from "@/lib/search-events"
@@ -30,30 +47,57 @@ import {
 } from "@/components/ui/sheet"
 import {
 	companyNavLinks,
-	primaryNavLinks,
+	midNavLinks,
+	serviceMegaHighlights,
 	serviceNavLinks,
+	type MegaNavItem,
 	type NavLink,
 } from "@/lib/navigation"
 import { siteConfig } from "@/lib/site"
 import { cn } from "@/lib/utils"
 
-function ListItem({ href, label, description }: NavLink) {
+const megaIcons: Record<MegaNavItem["icon"], LucideIcon> = {
+	wrench: Wrench,
+	droplets: Droplets,
+	building: Building2,
+	siren: Siren,
+	users: Users,
+	star: Star,
+	briefcase: Briefcase,
+	phone: Phone,
+	badge: BadgeCheck,
+	wallet: Wallet,
+	shield: ShieldCheck,
+	help: CircleHelp,
+}
+
+const triggerClassName =
+	"hover:text-primary-bright focus:text-primary-bright data-[active]:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[active]:bg-transparent data-[state=open]:bg-transparent"
+
+function MegaLink({ href, label, description, icon }: MegaNavItem) {
+	const Icon = megaIcons[icon]
+
 	return (
 		<li>
 			<NavigationMenuLink asChild>
 				<Link
-					className="hover:bg-accent hover:text-accent-foreground focus-visible:ring-ring block rounded-md p-3 transition-colors outline-none focus-visible:ring-2"
+					className="hover:bg-muted focus-visible:ring-ring group flex items-start gap-3 rounded-md p-3 transition-colors outline-none focus-visible:ring-2"
 					href={href as Route}
 					prefetch
 				>
-					<span className="text-foreground text-sm font-extrabold tracking-[-0.01em]">
-						{label}
+					<span className="bg-accent text-accent-foreground mt-0.5 grid size-9 shrink-0 place-items-center rounded-md">
+						<Icon className="size-4" aria-hidden="true" />
 					</span>
-					{description ? (
-						<span className="text-muted-foreground mt-1 block text-sm leading-snug">
-							{description}
+					<span className="min-w-0">
+						<span className="text-foreground group-hover:text-primary block text-sm font-extrabold tracking-[-0.01em]">
+							{label}
 						</span>
-					) : null}
+						{description ? (
+							<span className="text-muted-foreground mt-1 block text-sm leading-snug">
+								{description}
+							</span>
+						) : null}
+					</span>
 				</Link>
 			</NavigationMenuLink>
 		</li>
@@ -81,22 +125,206 @@ function MobileNavLink({ href, label, description }: NavLink) {
 	)
 }
 
+function ServicesMegaMenu() {
+	return (
+		<div className="w-full">
+			<div className="container-shell grid gap-8 py-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1.4fr)_minmax(0,0.9fr)] lg:gap-10">
+				<div className="surface-dark relative overflow-hidden rounded-lg p-6 sm:p-7">
+					<div
+						aria-hidden="true"
+						className="pointer-events-none absolute inset-0 opacity-80"
+						style={{
+							background: `
+								radial-gradient(ellipse 80% 70% at 10% 0%, color-mix(in srgb, var(--primary) 34%, transparent), transparent 70%),
+								linear-gradient(160deg, var(--ink) 0%, var(--ink-soft) 100%)
+							`,
+						}}
+					/>
+					<div className="relative">
+						<p className="type-eyebrow text-primary-bright">Local specialists</p>
+						<h3 className="mt-3 text-2xl font-extrabold tracking-[-0.03em] text-white">
+							Plumbing &amp; septic done right the first time
+						</h3>
+						<p className="mt-3 text-sm leading-relaxed text-[#e8e8e4]">
+							From drain diagnostics to engineered septic work — clear options,
+							licensed crews, and service across Santa Cruz County.
+						</p>
+						<div className="mt-6 flex flex-col gap-3 sm:flex-row">
+							<a
+								className={cn(buttonVariants({ size: "lg" }), "gap-2")}
+								href={siteConfig.phoneHref}
+							>
+								<Phone className="size-4" aria-hidden="true" />
+								Call {siteConfig.phone}
+							</a>
+							<Link
+								className={cn(
+									buttonVariants({ variant: "inverse", size: "lg" }),
+									"gap-2",
+								)}
+								href={"/services" as Route}
+								prefetch
+							>
+								Browse all services
+								<ArrowRight className="size-4" aria-hidden="true" />
+							</Link>
+						</div>
+					</div>
+				</div>
+
+				<div>
+					<p className="text-muted-foreground mb-3 text-xs font-extrabold tracking-[0.16em] uppercase">
+						Service categories
+					</p>
+					<ul className="grid gap-1 sm:grid-cols-2">
+						{serviceNavLinks.map((item) => (
+							<MegaLink key={item.href} {...item} />
+						))}
+					</ul>
+				</div>
+
+				<div className="border-border lg:border-l lg:pl-8">
+					<p className="text-muted-foreground mb-3 text-xs font-extrabold tracking-[0.16em] uppercase">
+						Popular right now
+					</p>
+					<ul className="space-y-1">
+						{serviceMegaHighlights.map((item) => (
+							<li key={item.href}>
+								<NavigationMenuLink asChild>
+									<Link
+										className="hover:bg-muted focus-visible:ring-ring group block rounded-md p-3 transition-colors outline-none focus-visible:ring-2"
+										href={item.href as Route}
+										prefetch
+									>
+										<span className="text-foreground group-hover:text-primary flex items-center justify-between gap-3 text-sm font-extrabold tracking-[-0.01em]">
+											{item.label}
+											<ArrowRight
+												className="text-muted-foreground size-4 opacity-0 transition group-hover:opacity-100"
+												aria-hidden="true"
+											/>
+										</span>
+										<span className="text-muted-foreground mt-1 block text-sm leading-snug">
+											{item.description}
+										</span>
+									</Link>
+								</NavigationMenuLink>
+							</li>
+						))}
+					</ul>
+					<p className="text-muted-foreground mt-5 text-xs font-bold">
+						{siteConfig.licenses} · {siteConfig.hours}
+					</p>
+				</div>
+			</div>
+		</div>
+	)
+}
+
+function CompanyMegaMenu() {
+	return (
+		<div className="w-full">
+			<div className="container-shell grid gap-8 py-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] lg:gap-12">
+				<div className="overflow-hidden rounded-lg">
+					<div className="relative aspect-[16/10] min-h-48">
+						<Image
+							alt="Coastal redwoods in Wade's Santa Cruz County service area"
+							className="object-cover"
+							fill
+							sizes="(min-width: 1024px) 28rem, 100vw"
+							src="/images/locations/santa-cruz-redwoods.webp"
+						/>
+						<div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/25 to-transparent" />
+						<div className="absolute inset-x-0 bottom-0 p-5 sm:p-6">
+							<p className="text-primary-bright text-xs font-extrabold tracking-[0.16em] uppercase">
+								Family-owned · Local
+							</p>
+							<p className="mt-2 max-w-sm text-lg font-extrabold tracking-[-0.02em] text-white">
+								Trusted plumbing &amp; septic for Santa Cruz County homes and
+								businesses.
+							</p>
+						</div>
+					</div>
+					<div className="border-border bg-secondary/60 flex flex-wrap gap-x-5 gap-y-2 border border-t-0 px-5 py-4 text-sm font-bold">
+						<span className="inline-flex items-center gap-2">
+							<BadgeCheck className="text-primary size-4" aria-hidden="true" />
+							{siteConfig.licenses}
+						</span>
+						<span className="text-muted-foreground inline-flex items-center gap-2">
+							<Phone className="size-4" aria-hidden="true" />
+							{siteConfig.phone}
+						</span>
+					</div>
+				</div>
+
+				<div>
+					<p className="text-muted-foreground mb-3 text-xs font-extrabold tracking-[0.16em] uppercase">
+						Company
+					</p>
+					<ul className="grid gap-1 sm:grid-cols-2">
+						{companyNavLinks.map((item) => (
+							<MegaLink key={item.href} {...item} />
+						))}
+					</ul>
+					<div className="border-border mt-6 flex flex-col gap-3 border-t pt-6 sm:flex-row sm:items-center">
+						<a
+							className={cn(buttonVariants({ size: "lg" }), "gap-2")}
+							href={siteConfig.phoneHref}
+						>
+							<Phone className="size-4" aria-hidden="true" />
+							Call {siteConfig.phone}
+						</a>
+						<Link
+							className={cn(
+								buttonVariants({ variant: "outline", size: "lg" }),
+								"gap-2",
+							)}
+							href={"/contact" as Route}
+							prefetch
+						>
+							Get a free quote
+							<ArrowRight className="size-4" aria-hidden="true" />
+						</Link>
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+}
+
 export function SiteHeaderNav() {
 	return (
 		<>
 			<NavigationMenu
-				className="hidden lg:flex"
+				className="static hidden max-w-none flex-1 justify-center lg:flex"
 				aria-label="Primary navigation"
 			>
 				<NavigationMenuList>
-					{primaryNavLinks.map((item) => (
+					<NavigationMenuItem>
+						<NavigationMenuLink asChild>
+							<Link
+								className={cn(navigationMenuTriggerStyle(), triggerClassName)}
+								href={"/" as Route}
+								prefetch
+							>
+								Home
+							</Link>
+						</NavigationMenuLink>
+					</NavigationMenuItem>
+
+					<NavigationMenuItem>
+						<NavigationMenuTrigger className={triggerClassName}>
+							Services
+						</NavigationMenuTrigger>
+						<NavigationMenuContent>
+							<ServicesMegaMenu />
+						</NavigationMenuContent>
+					</NavigationMenuItem>
+
+					{midNavLinks.map((item) => (
 						<NavigationMenuItem key={item.href}>
 							<NavigationMenuLink asChild>
 								<Link
-									className={cn(
-										navigationMenuTriggerStyle(),
-										"hover:text-primary-bright focus:text-primary-bright data-[active]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[active]:bg-transparent",
-									)}
+									className={cn(navigationMenuTriggerStyle(), triggerClassName)}
 									href={item.href as Route}
 									prefetch
 								>
@@ -107,28 +335,11 @@ export function SiteHeaderNav() {
 					))}
 
 					<NavigationMenuItem>
-						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
-							Services
-						</NavigationMenuTrigger>
-						<NavigationMenuContent>
-							<ul className="grid w-[22rem] gap-1 p-3 md:w-[28rem] md:grid-cols-2">
-								{serviceNavLinks.map((item) => (
-									<ListItem key={item.href} {...item} />
-								))}
-							</ul>
-						</NavigationMenuContent>
-					</NavigationMenuItem>
-
-					<NavigationMenuItem>
-						<NavigationMenuTrigger className="hover:text-primary-bright focus:text-primary-bright data-[state=open]:text-primary-bright bg-transparent text-white hover:bg-transparent focus:bg-transparent data-[state=open]:bg-transparent">
+						<NavigationMenuTrigger className={triggerClassName}>
 							Company
 						</NavigationMenuTrigger>
 						<NavigationMenuContent>
-							<ul className="grid w-[20rem] gap-1 p-3">
-								{companyNavLinks.map((item) => (
-									<ListItem key={item.href} {...item} />
-								))}
-							</ul>
+							<CompanyMegaMenu />
 						</NavigationMenuContent>
 					</NavigationMenuItem>
 				</NavigationMenuList>
@@ -213,12 +424,7 @@ export function SiteHeaderNav() {
 							className="flex-1 overflow-y-auto px-2 py-3"
 							aria-label="Mobile navigation"
 						>
-							<p className="text-muted-foreground px-3 pb-1 text-xs font-extrabold tracking-[0.14em] uppercase">
-								Explore
-							</p>
-							{primaryNavLinks.map((item) => (
-								<MobileNavLink key={item.href} {...item} />
-							))}
+							<MobileNavLink href="/" label="Home" />
 
 							<Separator className="my-3" />
 
@@ -226,6 +432,12 @@ export function SiteHeaderNav() {
 								Services
 							</p>
 							{serviceNavLinks.map((item) => (
+								<MobileNavLink key={item.href} {...item} />
+							))}
+
+							<Separator className="my-3" />
+
+							{midNavLinks.map((item) => (
 								<MobileNavLink key={item.href} {...item} />
 							))}
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -20,31 +20,34 @@ export function SiteHeader() {
 				</div>
 			</div>
 
-			<div className="container-shell flex h-16 items-center justify-between gap-3 sm:h-18">
-				<Link
-					className="flex min-w-0 items-center gap-2.5 sm:gap-3"
-					href="/"
-					aria-label="Wade's Plumbing & Septic home"
-					prefetch
-				>
-					<Image
-						alt="Wade's Plumbing & Septic logo"
-						className="size-10 shrink-0 rounded-md sm:size-11"
-						height={44}
-						src="/images/brand/wades-mark-sm.webp"
-						width={44}
-					/>
-					<span className="leading-none">
-						<span className="block text-[0.95rem] font-extrabold tracking-[-0.03em] text-white sm:text-lg">
-							Wade&apos;s Plumbing
+			{/* Relative shell so mega-menu viewports span the full header width */}
+			<div className="relative">
+				<div className="container-shell flex h-16 items-center justify-between gap-3 sm:h-18">
+					<Link
+						className="flex min-w-0 items-center gap-2.5 sm:gap-3"
+						href="/"
+						aria-label="Wade's Plumbing & Septic home"
+						prefetch
+					>
+						<Image
+							alt="Wade's Plumbing & Septic logo"
+							className="size-10 shrink-0 rounded-md sm:size-11"
+							height={44}
+							src="/images/brand/wades-mark-sm.webp"
+							width={44}
+						/>
+						<span className="leading-none">
+							<span className="block text-[0.95rem] font-extrabold tracking-[-0.03em] text-white sm:text-lg">
+								Wade&apos;s Plumbing
+							</span>
+							<span className="text-primary-bright mt-1 block text-[0.65rem] font-extrabold tracking-[0.18em] uppercase">
+								&amp; Septic
+							</span>
 						</span>
-						<span className="text-primary-bright mt-1 block text-[0.65rem] font-extrabold tracking-[0.18em] uppercase">
-							&amp; Septic
-						</span>
-					</span>
-				</Link>
+					</Link>
 
-				<SiteHeaderNav />
+					<SiteHeaderNav />
+				</div>
 			</div>
 		</header>
 	)

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -10,18 +10,22 @@ import { cn } from "@/lib/utils"
 export function NavigationMenu({
 	className,
 	children,
+	viewport = true,
 	...props
-}: React.ComponentProps<typeof NavigationMenuPrimitive.Root>) {
+}: React.ComponentProps<typeof NavigationMenuPrimitive.Root> & {
+	viewport?: boolean
+}) {
 	return (
 		<NavigationMenuPrimitive.Root
+			data-viewport={viewport}
 			className={cn(
-				"relative z-10 flex max-w-max flex-1 items-center justify-center",
+				"group/navigation-menu relative z-10 flex max-w-max flex-1 items-center justify-center",
 				className,
 			)}
 			{...props}
 		>
 			{children}
-			<NavigationMenuViewport />
+			{viewport ? <NavigationMenuViewport /> : null}
 		</NavigationMenuPrimitive.Root>
 	)
 }
@@ -73,8 +77,8 @@ export function NavigationMenuContent({
 	return (
 		<NavigationMenuPrimitive.Content
 			className={cn(
-				"top-0 left-0 w-full md:absolute md:w-auto",
-				"data-[motion^=from-]:animate-fade data-[motion^=to-]:animate-fade",
+				"top-0 left-0 w-full",
+				"data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-4 data-[motion=from-start]:slide-in-from-left-4 data-[motion=to-end]:slide-out-to-right-4 data-[motion=to-start]:slide-out-to-left-4",
 				className,
 			)}
 			{...props}
@@ -89,10 +93,10 @@ function NavigationMenuViewport({
 	...props
 }: React.ComponentProps<typeof NavigationMenuPrimitive.Viewport>) {
 	return (
-		<div className="absolute top-full left-0 flex w-full justify-center md:w-auto">
+		<div className="absolute inset-x-0 top-full z-50 flex justify-center">
 			<NavigationMenuPrimitive.Viewport
 				className={cn(
-					"origin-top-center border-border bg-popover text-popover-foreground relative mt-2 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-lg border shadow-[var(--shadow-edge)] md:w-[var(--radix-navigation-menu-viewport-width)]",
+					"bg-card text-card-foreground border-border relative h-[var(--radix-navigation-menu-viewport-height)] w-full origin-top overflow-hidden border-b shadow-[0_18px_40px_-28px_rgba(16,18,20,0.55)] transition-[height] duration-200",
 					className,
 				)}
 				{...props}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -4,60 +4,125 @@ export type NavLink = {
 	description?: string
 }
 
-export const serviceNavLinks: NavLink[] = [
+export type MegaNavItem = NavLink & {
+	icon:
+		| "wrench"
+		| "droplets"
+		| "building"
+		| "siren"
+		| "users"
+		| "star"
+		| "briefcase"
+		| "phone"
+		| "badge"
+		| "wallet"
+		| "shield"
+		| "help"
+}
+
+export const serviceNavLinks: MegaNavItem[] = [
 	{
 		href: "/services",
 		label: "All Services",
-		description: "Browse plumbing, septic, and commercial work.",
+		description: "Browse plumbing, septic, and commercial work across Santa Cruz County.",
+		icon: "wrench",
 	},
 	{
 		href: "/service-category/plumbing",
 		label: "Residential Plumbing",
-		description: "Leaks, drains, fixtures, water heaters, and more.",
+		description: "Leaks, drains, fixtures, water heaters, and whole-home repairs.",
+		icon: "droplets",
 	},
 	{
 		href: "/service-category/septic",
 		label: "Septic Systems",
 		description: "Inspections, pumping, repairs, and engineered installs.",
+		icon: "badge",
 	},
 	{
 		href: "/service-category/commercial",
 		label: "Commercial Plumbing",
 		description: "Business, restaurant, and multi-unit service.",
+		icon: "building",
 	},
 	{
 		href: "/service-category/emergency-services",
 		label: "Urgent Repairs",
-		description:
-			"Priority help for leaks, backups, and time-sensitive repairs.",
+		description: "Priority help for leaks, backups, and time-sensitive repairs.",
+		icon: "siren",
 	},
 ]
 
-export const companyNavLinks: NavLink[] = [
+export const serviceMegaHighlights = [
+	{
+		href: "/service-offerings/video-inspections",
+		label: "Video Inspections",
+		description: "See exactly what’s happening inside the line.",
+	},
+	{
+		href: "/service-offerings/hydro-jetting",
+		label: "Hydro Jetting",
+		description: "High-pressure clearing for stubborn drain buildup.",
+	},
+	{
+		href: "/service-offerings/septic-tank-cleaning-and-pumping",
+		label: "Septic Pumping",
+		description: "Keep your system healthy before problems start.",
+	},
+] as const
+
+export const companyNavLinks: MegaNavItem[] = [
 	{
 		href: "/about-us",
 		label: "About Us",
 		description: "Family-owned local plumbing and septic team.",
+		icon: "users",
 	},
 	{
 		href: "/testimonials",
 		label: "Customer Reviews",
-		description: "What homeowners and partners say.",
+		description: "What homeowners and partners say about Wade’s.",
+		icon: "star",
 	},
 	{
 		href: "/careers",
 		label: "Careers",
-		description: "Join the Wade's field and office team.",
+		description: "Join the Wade’s field and office team.",
+		icon: "briefcase",
 	},
 	{
 		href: "/contact",
 		label: "Contact",
 		description: "Call, message, or request a free quote.",
+		icon: "phone",
 	},
+	{
+		href: "/faq",
+		label: "FAQ",
+		description: "Straight answers about service, timing, and next steps.",
+		icon: "help",
+	},
+	{
+		href: "/financing",
+		label: "Financing",
+		description: "Options that make larger projects more manageable.",
+		icon: "wallet",
+	},
+	{
+		href: "/warranties",
+		label: "Warranties",
+		description: "Coverage details for workmanship and materials.",
+		icon: "shield",
+	},
+]
+
+/** Top-level links shown after Services and before Company. */
+export const midNavLinks: NavLink[] = [
+	{ href: "/service-areas", label: "Service Area" },
+	{ href: "/expert-tips", label: "Expert Tips" },
 ]
 
 export const primaryNavLinks: NavLink[] = [
 	{ href: "/", label: "Home" },
-	{ href: "/expert-tips", label: "Expert Tips" },
-	{ href: "/service-areas", label: "Service Areas" },
+	...midNavLinks,
 ]

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -20,15 +20,14 @@ export const siteConfig = {
 export const primaryNavigation = [
 	{ href: "/", label: "Home" },
 	{ href: "/services", label: "Services" },
+	{ href: "/service-areas", label: "Service Area" },
 	{ href: "/expert-tips", label: "Expert Tips" },
-	{ href: "/service-areas", label: "Service Areas" },
 	{ href: "/about-us", label: "About Us" },
 ] as const
 
 export const companyNavigation = [
 	{ href: "/about-us", label: "About Us" },
 	{ href: "/testimonials", label: "Customer Reviews" },
-	{ href: "/service-areas", label: "Service Areas" },
 	{ href: "/faq", label: "FAQ" },
 	{ href: "/financing", label: "Financing" },
 	{ href: "/warranties", label: "Warranties" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Navigation dropdowns were small, poorly aligned panels that floated under the nav cluster. They’re now **full-width mega menus** anchored to the header, with richer content.

### Fixes
- Viewport is positioned against the full header width (`static` menu + `absolute inset-x-0` viewport), so panels line up edge-to-edge instead of offset under the link list
- **Services** mega menu: brand CTA column, category grid with icons, popular services
- **Company** mega menu: local imagery + license/phone strip, company links with icons, quote CTAs
- Nav order: **Home → Services → Service Area → Expert Tips → Company** (desktop + mobile)

## Validation
- `npx tsc --noEmit`
- `npx eslint` on touched files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

