### PR TITLE
Fix hero breadcrumbs rendering and clickability

### DIFF
--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -8,6 +8,78 @@ import { buttonVariants } from "@/components/ui/button"
 import { siteConfig } from "@/lib/site"
 import { cn } from "@/lib/utils"
 
+export type HeroBreadcrumb = {
+	label: string
+	/** Omit on the current page crumb (rendered as plain text). */
+	href?: Route
+}
+
+function buildBreadcrumbs({
+	title,
+	parent,
+	breadcrumbs,
+}: {
+	title: string
+	parent?: { href: Route; label: string }
+	breadcrumbs?: HeroBreadcrumb[]
+}): HeroBreadcrumb[] {
+	if (breadcrumbs?.length) return breadcrumbs
+
+	return [
+		{ href: "/" as Route, label: "Home" },
+		...(parent ? [{ href: parent.href, label: parent.label }] : []),
+		{ label: title },
+	]
+}
+
+function BreadcrumbTrail({ items }: { items: HeroBreadcrumb[] }) {
+	return (
+		<nav aria-label="Breadcrumb" className="mb-5 sm:mb-7">
+			<ol className="header-muted flex flex-wrap items-center gap-x-1 gap-y-1 text-xs font-bold">
+				{items.map((item, index) => {
+					const isCurrent = index === items.length - 1
+					const separator =
+						index > 0 ? (
+							<ChevronRight
+								aria-hidden="true"
+								className="mx-0.5 size-3 shrink-0 opacity-70"
+							/>
+						) : null
+
+					return (
+						<li
+							key={`${item.label}-${index}`}
+							className="flex min-w-0 items-center"
+						>
+							{separator}
+							{item.href && !isCurrent ? (
+								<Link
+									className="rounded-sm transition-colors hover:text-white focus-visible:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--primary-bright)_70%,transparent)]"
+									href={item.href}
+									prefetch={false}
+								>
+									{item.label}
+								</Link>
+							) : (
+								<span
+									aria-current={isCurrent ? "page" : undefined}
+									className={cn(
+										"min-w-0 truncate",
+										isCurrent ? "text-white/90" : undefined,
+									)}
+									title={item.label}
+								>
+									{item.label}
+								</span>
+							)}
+						</li>
+					)
+				})}
+			</ol>
+		</nav>
+	)
+}
+
 export function ContentHero({
 	title,
 	description,
@@ -15,56 +87,49 @@ export function ContentHero({
 	image,
 	imageAlt,
 	parent,
+	breadcrumbs,
 }: {
 	title: string
 	description: string
 	eyebrow?: string
 	image?: string
 	imageAlt?: string
+	/** Optional middle crumb (e.g. Services, Expert Tips, Service Areas). */
 	parent?: { href: Route; label: string }
+	/** Full trail override. Last item is treated as the current page. */
+	breadcrumbs?: HeroBreadcrumb[]
 }) {
+	const trail = buildBreadcrumbs({ title, parent, breadcrumbs })
+
 	return (
 		<section className="surface-dark relative overflow-hidden">
 			{image ? (
-				<>
+				<div className="pointer-events-none absolute inset-0">
+					{/*
+					  Wrap fill Image so its absolutely positioned span cannot steal
+					  clicks from breadcrumb links and CTAs stacked above.
+					*/}
 					<Image
 						alt={imageAlt?.trim() || title}
-						className="object-cover opacity-40"
+						className="object-cover opacity-40 select-none"
 						fill
 						priority
 						quality={55}
 						sizes="100vw"
 						src={image}
 					/>
-					<div className="from-ink/75 via-ink/88 to-ink absolute inset-0 bg-linear-to-b" />
-					<div className="from-ink via-ink/70 to-ink/40 absolute inset-0 bg-linear-to-r" />
-				</>
+					<div
+						aria-hidden="true"
+						className="from-ink/75 via-ink/88 to-ink absolute inset-0 bg-linear-to-b"
+					/>
+					<div
+						aria-hidden="true"
+						className="from-ink via-ink/70 to-ink/40 absolute inset-0 bg-linear-to-r"
+					/>
+				</div>
 			) : null}
-			<div className="container-shell relative py-12 sm:py-16 lg:py-20">
-				<nav
-					className="header-muted mb-5 flex flex-wrap items-center gap-1 text-xs font-bold sm:mb-7"
-					aria-label="Breadcrumb"
-				>
-					<Link
-						className="transition-colors hover:text-white"
-						href="/"
-						prefetch={false}
-					>
-						Home
-					</Link>
-					{parent ? (
-						<>
-							<ChevronRight className="size-3 opacity-70" />
-							<Link
-								className="transition-colors hover:text-white"
-								href={parent.href}
-								prefetch={false}
-							>
-								{parent.label}
-							</Link>
-						</>
-					) : null}
-				</nav>
+			<div className="container-shell relative z-10 py-12 sm:py-16 lg:py-20">
+				<BreadcrumbTrail items={trail} />
 				{eyebrow ? <Badge tone="bright">{eyebrow}</Badge> : null}
 				<h1 className="type-display mt-4 max-w-4xl text-white sm:mt-5">
 					{title}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hero breadcrumbs looked broken: trails often showed only **Home**, and background media could intercept clicks on the crumb links.

## Changes

- Always render a full trail: **Home → optional parent → current page**
- Current page is plain text with `aria-current="page"` (not a self-link)
- Use a semantic `<ol>` list for the crumb trail
- Wrap the fill `Image` and gradient overlays in `pointer-events-none` so breadcrumb/CTA clicks work
- Raise hero content with `z-10`

Existing `parent` props on service, tip, and service-area pages keep working; no call-site changes required.

## Test plan

- [ ] Service page: `Home → Services → {service}` and parent link navigates
- [ ] Expert tip: `Home → Expert Tips → {post}` and parent link navigates
- [ ] Service area landing: `Home → Service Areas → {city}`
- [ ] Top-level page (About/Contact): `Home → {page}`
- [ ] Click Home / parent crumbs (not blocked by hero image)
- [ ] Current page crumb is not a link

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

