### PR TITLE
Update contact page with real Wade's business details

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -94,6 +94,14 @@ const localBusinessSchema = {
 	logo: `${siteConfig.url}/images/brand/wades-mark.webp`,
 	image: `${siteConfig.url}/images/locations/santa-cruz-plumber.webp`,
 	priceRange: "$$",
+	address: {
+		"@type": "PostalAddress",
+		streetAddress: siteConfig.address.street,
+		addressLocality: siteConfig.address.city,
+		addressRegion: siteConfig.address.region,
+		postalCode: siteConfig.address.postalCode,
+		addressCountry: "US",
+	},
 	areaServed: [
 		{ "@type": "AdministrativeArea", name: "Santa Cruz County, California" },
 		{ "@type": "AdministrativeArea", name: "Santa Clara County, California" },

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -32,7 +32,10 @@ export async function GET() {
 > ${siteConfig.description}
 
 Phone: ${siteConfig.phone}
+Email: ${siteConfig.email}
+Address: ${siteConfig.address.display}
 Hours: ${siteConfig.hours}
+License: ${siteConfig.licenses}
 Service area: ${siteConfig.serviceArea}
 
 ## Services

--- a/components/content-conversion-cta.tsx
+++ b/components/content-conversion-cta.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import Link from "next/link"
 import { ArrowRight, BadgeCheck, Clock, Phone, Star } from "lucide-react"
 
@@ -8,9 +9,26 @@ import { cn } from "@/lib/utils"
 
 export function ContentConversionCta({
 	conversion,
+	secondaryAction,
 }: {
 	conversion: ContentConversion
+	/** Override the secondary CTA (defaults to Contact / Get a Free Quote). */
+	secondaryAction?: {
+		href: string
+		label: string
+		external?: boolean
+	}
 }) {
+	const secondary = secondaryAction ?? {
+		href: "/contact",
+		label: "Get a Free Quote",
+		external: false,
+	}
+	const secondaryClassName = cn(
+		buttonVariants({ variant: "inverse", size: "xl" }),
+		"w-full justify-center gap-2 sm:w-auto",
+	)
+
 	return (
 		<section className="surface-dark relative overflow-hidden">
 			<div
@@ -52,17 +70,23 @@ export function ContentConversionCta({
 							<Phone className="size-5" />
 							Call {siteConfig.phone}
 						</a>
-						<Link
-							className={cn(
-								buttonVariants({ variant: "inverse", size: "xl" }),
-								"w-full justify-center gap-2 sm:w-auto",
-							)}
-							href="/contact"
-							prefetch
-						>
-							Get a Free Quote
-							<ArrowRight />
-						</Link>
+						{secondary.external ||
+						secondary.href.startsWith("mailto:") ||
+						secondary.href.startsWith("tel:") ? (
+							<a className={secondaryClassName} href={secondary.href}>
+								{secondary.label}
+								<ArrowRight />
+							</a>
+						) : (
+							<Link
+								className={secondaryClassName}
+								href={secondary.href as Route}
+								prefetch
+							>
+								{secondary.label}
+								<ArrowRight />
+							</Link>
+						)}
 					</div>
 
 					<ul className="text-white/70 motion-fade motion-delay-2 mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm font-bold">

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -2,6 +2,7 @@ import type { Route } from "next"
 
 import type { ContentDocument } from "@/lib/content"
 import { articleJsonLd, breadcrumbJsonLd, webPageJsonLd } from "@/lib/seo"
+import { siteConfig } from "@/lib/site"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentConversionCta } from "@/components/content-conversion-cta"
@@ -72,7 +73,18 @@ export function ContentPage({
 					/>
 				</aside>
 			</article>
-			<ContentConversionCta conversion={document.conversion} />
+			<ContentConversionCta
+				conversion={document.conversion}
+				secondaryAction={
+					document.slug === "contact"
+						? {
+								href: `mailto:${siteConfig.email}`,
+								label: "Email Us",
+								external: true,
+							}
+						: undefined
+				}
+			/>
 			<JsonLd
 				data={[
 					isPost ? articleJsonLd(document) : webPageJsonLd(document),

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -76,6 +76,9 @@ export function SiteFooter() {
 							Family-owned plumbing and septic specialists. Honest
 							recommendations, clear pricing, and quality workmanship.
 						</p>
+						<p className="mt-4 text-sm leading-relaxed text-white/65">
+							{siteConfig.address.display}
+						</p>
 						<p className="mt-4 text-xs font-bold text-white/45">
 							{siteConfig.licenses}
 						</p>

--- a/content/pages/contact-call-first.md
+++ b/content/pages/contact-call-first.md
@@ -1,6 +1,8 @@
 ---
 title: Talk to Wade's Plumbing & Septic
-description: Call first for service-area confirmation, issue triage, scheduling, and the fastest response to urgent plumbing or septic problems.
+description: >-
+  Call 831.225.4344 first for service-area confirmation, issue triage, scheduling,
+  and the fastest response to urgent plumbing or septic problems.
 eyebrow: Call-First Intake
 image: /images/team/wades-team.webp
 imageAlt: Wade's Plumbing and Septic team
@@ -9,7 +11,7 @@ noindex: true
 
 ## Call 831.225.4344
 
-For the fastest help, call with:
+For the fastest help, call or text with:
 
 - The property city or ZIP code
 - Plumbing, septic, or commercial service type
@@ -17,6 +19,6 @@ For the fastest help, call with:
 - When the problem started
 - Whether water or sewage is actively causing damage
 
-The team will confirm coverage, recommend the right service path, and provide the next available scheduling options.
+The team will confirm coverage, recommend the right service path, and share the next available scheduling options.
 
-Regular office hours are Monday through Friday, 9:00 AM–5:00 PM. Call 831.225.4344 to schedule service.
+Regular office hours are Monday through Friday, 9:00 AM to 5:00 PM. Office: 7737 Highway 9, Ben Lomond, CA 95005. Email: support@wadesinc.io.

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -1,68 +1,87 @@
 ---
 title: Contact Us
-description: We're here to help with all your plumbing and septic needs. Reach out
- to our team for prompt, professional service.
+description: >-
+  Call or text 831.225.4344, email support@wadesinc.io, or request service online.
+  Family-owned plumbing and septic for Santa Cruz County and selected Santa Clara
+  County communities. CSLB #1087260.
 order: 7
 image: /images/team/wades-team.webp
-imageAlt: Professional Wade's plumber at work
-eyebrow: Call During Business Hours
+imageAlt: Wade's Plumbing & Septic team ready for service calls
+eyebrow: Call or Text 831.225.4344
 ---
 
 # Contact Wade's Plumbing & Septic
 
-We're here to help with all your plumbing and septic needs. Reach out to our team for prompt, professional service.
+Need a plumber or septic tech in Santa Cruz County or nearby foothill communities? Call or text **[831.225.4344](tel:+18312254344)**, email **[support@wadesinc.io](mailto:support@wadesinc.io)**, or use the request options on this page. We confirm your address, triage the issue, and get you on the schedule.
 
-Updated July 2026
+## Call or text
 
-As summer unfolds in Santa Cruz County, California, it's crucial to remember that regular maintenance of septic systems can prevent costly issues down the line. The warm season is an ideal time to schedule a professional septic inspection to ensure your system operates efficiently. Our team is ready to assist with comprehensive septic maintenance services, helping to safeguard your home and the environment. For more information on our septic maintenance services, visit the [service area page](/service-areas/).
+**[831.225.4344](tel:+18312254344)**
 
-## Request Service
+Use this number for scheduling, questions, and urgent plumbing or septic problems. Texting works when you cannot talk. Have ready:
 
-For service requests, questions, or to schedule an appointment, call us or fill out the form below. Our team will respond promptly to address your needs.
+- City or ZIP for the property
+- Whether the issue is plumbing, septic, or commercial
+- Which fixtures or equipment are affected
+- When the problem started
+- Whether water or sewage is actively causing damage
 
-## Emergency Service
+For the fastest intake path, see our [call-first checklist](/contact-call-first).
 
-For plumbing emergencies, please call our emergency line for immediate assistance. We provide emergency service throughout our service areas.
+## Email
 
-## Our Office
+**[support@wadesinc.io](mailto:support@wadesinc.io)**
 
-123 Main Street 
-Anytown, USA 12345 
-Phone: (555) 123-4567 
-Email: info@wadesplumbing.com 
+Best for photos, permit questions, and non-urgent follow-up. Include the property address and a short description of what is happening.
 
-## Hours of Operation
+## Office
 
-Monday - Friday: 7:00 AM - 6:00 PM 
-Saturday: 8:00 AM - 2:00 PM 
-Sunday: Closed (Emergency Services Available)
+**Wade's Plumbing & Septic**  
+7737 Highway 9  
+Ben Lomond, CA 95005
 
-## Serving Santa Cruz County, CA
+We are based in the San Lorenzo Valley and dispatch across Santa Cruz County and selected Santa Clara County foothill communities (including Los Gatos and Saratoga, generally west of Highway 101). Confirm coverage when you call. Browse the [service area map](/service-areas) for approximate coverage.
 
-Wade's Plumbing & Septic is proud to offer our expert services to the communities of Santa Cruz County, including Santa Cruz, Capitola, Scotts Valley, Watsonville, and Aptos. Our team is dedicated to providing reliable plumbing and septic solutions to residents and businesses throughout the area.
+## Hours
 
-Contractor License: C-42 (CA) / State License (GA)
+- **Monday through Friday:** 9:00 AM to 5:00 PM
+- **Saturday and Sunday:** Closed for routine scheduling
 
-Office Hours: Monday – Friday, 9am – 5pm
+Call **[831.225.4344](tel:+18312254344)** during office hours to book service. If you reach us outside those hours, leave a message or text and we will return contact on the next business day.
 
-Emergency Line: Available
+## Licensing
 
-Our service area extends across Santa Cruz County, ensuring that you receive the highest quality plumbing and septic services right in your community.
+- **California CSLB #1087260**
+- Classifications include **C-36** (Plumbing) and **C-42** (Sanitation System)
 
-## Frequently Asked Questions
+Look up the license on the [CSLB license check](https://www.cslb.ca.gov/OnlineServices/CheckLicenseII/CheckLicense.aspx) before you hire. We are family-owned, licensed, and insured for the work we perform in California.
 
-### What is the cost range for plumbing and septic services in Santa Cruz County, CA?
+## Service area
 
-Our pricing varies based on the service required. For a detailed estimate, contact us directly, and we’ll provide a transparent quote tailored to your specific needs in Santa Cruz County.
+We regularly serve communities across Santa Cruz County (including Santa Cruz, Capitola, Scotts Valley, Aptos, Watsonville, Felton, Ben Lomond, Boulder Creek, and nearby towns) plus selected Santa Clara County foothill addresses. If you are unsure whether your property is in range, call with the street address and we will tell you straight.
 
-### What should I expect during a service visit from Wade's Plumbing & Septic?
+## Request service
 
-Our professional team will arrive on time, assess your situation, and provide efficient solutions. We prioritize minimizing disruption to your daily activities while ensuring top-quality service.
+Tell us what is going on and we will point you to the right next step: inspection, repair, pumping, water heater work, drain clearing, or engineered septic options. Clear pricing before work begins. No sales pressure.
 
-### What is the typical timeline for completing a plumbing or septic service?
+## Frequently asked questions
 
-The timeline depends on the complexity of the job. Most services are completed within a day, but we’ll provide a more accurate timeframe during our initial assessment.
+### How do I get a quote?
 
-### Why should I choose Wade's Plumbing & Septic for services in Santa Cruz County, CA?
+Call or text **831.225.4344** or email **support@wadesinc.io** with the property address and a description of the problem. Many jobs need an on-site look before we can give a firm number. We explain options before work starts.
 
-Wade's Plumbing & Septic offers expert, reliable service with a deep understanding of local needs. Our commitment to quality and customer satisfaction sets us apart as a trusted provider in Santa Cruz County.
+### Do you offer emergency plumbing help?
+
+Call **831.225.4344**. During office hours we triage urgent leaks, backups, and septic alarms as quickly as the schedule allows. Outside office hours, leave a message or text with the address and what is happening so we can respond as soon as we are available.
+
+### What should I expect on a service visit?
+
+We confirm the address and issue when you book, arrive ready to diagnose, explain what we find in plain language, and complete agreed work with testing and cleanup. You get clear recommendations, not a hard sell.
+
+### How long does a typical job take?
+
+Many drain, fixture, and water heater visits finish the same day. Septic inspections, pumping, and engineered system work depend on site conditions, permits, and parts. We give a realistic timeframe after we understand the job.
+
+### Why choose Wade's?
+
+We are local, family-owned, and licensed for plumbing and onsite wastewater work (CSLB #1087260). We know Santa Cruz County soils, older mountain plumbing, coastal rentals, and county septic expectations. Honest assessment first; then the right fix.

--- a/lib/content-conversion.ts
+++ b/lib/content-conversion.ts
@@ -158,8 +158,30 @@ function parseConversionBundle(
 	}
 }
 
+/** Utility/company pages where "Get local help with {title}" reads broken. */
+const PAGE_CTA_TITLES: Record<string, string> = {
+	"contact us": "Ready to schedule service?",
+	contact: "Ready to schedule service?",
+	"about us": "Need a local licensed team you can trust?",
+	about: "Need a local licensed team you can trust?",
+	faq: "Still have a plumbing or septic question?",
+	faqs: "Still have a plumbing or septic question?",
+	"frequently asked questions": "Still have a plumbing or septic question?",
+	financing: "Want clear options before work begins?",
+	warranties: "Questions about coverage or warranties?",
+	careers: "Interested in joining the Wade's team?",
+	testimonials: "Ready to see what neighbors experience?",
+	"customer reviews": "Ready to see what neighbors experience?",
+	"privacy policy": "Need help with a plumbing or septic issue?",
+	"terms of service": "Need help with a plumbing or septic issue?",
+	"thank you": "We received your message",
+}
+
 function fallbackTitle(title: string) {
 	const cleaned = title.replace(/\?$/, "").trim()
+	const mapped = PAGE_CTA_TITLES[cleaned.toLowerCase()]
+	if (mapped) return mapped
+
 	// Avoid "Ready for help with Ensure Optimal..." when titles already read as CTAs.
 	if (SOFT_CTA_HEADING.test(cleaned) || /^(get|need|want)\b/i.test(cleaned)) {
 		return cleaned
@@ -246,14 +268,23 @@ export function extractContentConversion(
 	}
 }
 
+const PAGE_CTA_DESCRIPTIONS: Record<string, string> = {
+	"contact us":
+		"Call or text 831.225.4344. We will confirm your address, triage the issue, and get you on the schedule with clear next steps.",
+	contact:
+		"Call or text 831.225.4344. We will confirm your address, triage the issue, and get you on the schedule with clear next steps.",
+}
+
 export function normalizeConversion(
 	conversion: ContentConversion | null | undefined,
 	fallback: { title: string; description: string },
 ): ContentConversion {
 	const title = conversion?.title?.trim() || fallbackTitle(fallback.title)
+	const pageKey = fallback.title.replace(/\?$/, "").trim().toLowerCase()
 
 	const description =
 		conversion?.description?.trim() ||
+		PAGE_CTA_DESCRIPTIONS[pageKey] ||
 		fallback.description.trim() ||
 		"Talk with a local licensed team for clear options, honest pricing, and work done the right way."
 
@@ -271,10 +302,15 @@ export function normalizeConversion(
 }
 
 function defaultTestimonialsFor(topic: string): ContentTestimonial[] {
-	const focus = topic.replace(/\s+/g, " ").trim() || "plumbing and septic work"
+	const cleaned = topic.replace(/\s+/g, " ").trim()
+	const isUtilityPage = Boolean(PAGE_CTA_TITLES[cleaned.toLowerCase()])
+	const focus = isUtilityPage
+		? "our plumbing and septic work"
+		: cleaned.toLowerCase() || "plumbing and septic work"
+
 	return [
 		{
-			quote: `Clear communication and solid workmanship. The team made ${focus.toLowerCase()} straightforward from the first call.`,
+			quote: `Clear communication and solid workmanship. The team made ${focus} straightforward from the first call.`,
 			name: "Sarah",
 			location: "Santa Cruz",
 		},

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -7,8 +7,15 @@ export const siteConfig = {
 	phone: "831.225.4344",
 	phoneHref: "tel:+18312254344",
 	email: "support@wadesinc.io",
-	hours: "Mon - Fri 9:00am - 5:00pm",
-	licenses: "CA: CSLB #1087260",
+	hours: "Mon to Fri 9:00am to 5:00pm",
+	address: {
+		street: "7737 Highway 9",
+		city: "Ben Lomond",
+		region: "CA",
+		postalCode: "95005",
+		display: "7737 Highway 9, Ben Lomond, CA 95005",
+	},
+	licenses: "CA CSLB #1087260 (C-36 Plumbing, C-42 Sanitation System)",
 	serviceArea: "Santa Cruz County & selected Santa Clara County, CA",
 	social: {
 		facebook: "https://www.facebook.com/wadesplumbingandseptic/",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The contact page still had placeholder copy (Anytown address, 555 number, wrong hours, Georgia license noise, seasonal SEO filler). This replaces it with verified public business details and syncs `siteConfig`, footer, and LocalBusiness schema.

Also fixes the bottom conversion band that previously read **“Get local help with Contact Us?”**

## Verified details used

| Field | Value | Sources |
| --- | --- | --- |
| Phone | 831.225.4344 | Site config + public listings |
| Email | support@wadesinc.io | Site config / prior live site |
| Office | 7737 Highway 9, Ben Lomond, CA 95005 | MapQuest, SepticMind/Yelp directory, BestProsInTown |
| Hours | Monday through Friday, 9:00 AM to 5:00 PM | BestProsInTown + site config |
| License | CSLB #1087260, C-36 + C-42 | Contractor directory / CSLB listings |

## Changes

- Rewrote `content/pages/contact.md` and `contact-call-first.md`
- Extended `siteConfig` with address + clearer license string
- Added address to footer and LocalBusiness JSON-LD
- Contact bottom CTA now reads **Ready to schedule service?** with call/email actions (not “Get local help with Contact Us”)

## Test plan

- [ ] `/contact` shows Ben Lomond address, 831.225.4344, support@wadesinc.io
- [ ] Bottom section title is “Ready to schedule service?” (not “Get local help with Contact Us”)
- [ ] Secondary CTA is Email Us (not Get a Free Quote looping to /contact)
- [ ] No Anytown / 555 placeholders
- [ ] `npm run ci:content` and `npm run typecheck` pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

