### PR TITLE
Standardize all emails to support@wadesinc.io

### DIFF
--- a/content/pages/careers/customer-service-representative.md
+++ b/content/pages/careers/customer-service-representative.md
@@ -42,4 +42,4 @@ Wade's Plumbing & Septic is an equal opportunity employer committed to creating 
 
 ## How to Apply
 
-Submit your resume and cover letter through our online application form or email careers@wadesplumbing.com.
+Submit your resume and cover letter through our online application form or email [support@wadesinc.io](mailto:support@wadesinc.io).

--- a/content/pages/careers/licensed-plumber.md
+++ b/content/pages/careers/licensed-plumber.md
@@ -43,4 +43,4 @@ Wade's Plumbing & Septic is an equal opportunity employer committed to creating 
 
 ## How to Apply
 
-Submit your resume and cover letter through our online application form or email careers@wadesplumbing.com.
+Submit your resume and cover letter through our online application form or email [support@wadesinc.io](mailto:support@wadesinc.io).

--- a/content/pages/careers/septic-system-installer.md
+++ b/content/pages/careers/septic-system-installer.md
@@ -43,4 +43,4 @@ Wade's Plumbing & Septic is an equal opportunity employer committed to creating 
 
 ## How to Apply
 
-Submit your resume and cover letter through our online application form or email careers@wadesplumbing.com.
+Submit your resume and cover letter through our online application form or email [support@wadesinc.io](mailto:support@wadesinc.io).

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -29,7 +29,7 @@ For plumbing emergencies, please call our emergency line for immediate assistanc
 123 Main Street 
 Anytown, USA 12345 
 Phone: (555) 123-4567 
-Email: info@wadesplumbing.com 
+Email: [support@wadesinc.io](mailto:support@wadesinc.io) 
 
 ## Hours of Operation
 

--- a/scripts/ci/validate-content.mjs
+++ b/scripts/ci/validate-content.mjs
@@ -83,6 +83,16 @@ for (const collection of COLLECTIONS) {
 				`${file}: spaced hyphen aside (" - ") is not allowed; use parentheses, a comma, a colon, or a new sentence`,
 			)
 		}
+
+		// Only the working inbox is allowed in published content.
+		const emails = source.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi) ?? []
+		for (const email of emails) {
+			if (email.toLowerCase() !== "support@wadesinc.io") {
+				errors.push(
+					`${file}: email "${email}" is not allowed; use support@wadesinc.io`,
+				)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`careers@wadesplumbing.com` and `info@wadesplumbing.com` were still in content. The only working inbox is **support@wadesinc.io**.

## Changes

- Careers role pages now point applicants to `support@wadesinc.io`
- Contact page email updated to `support@wadesinc.io`
- Content CI rejects any other email address in markdown

`siteConfig.email` was already `support@wadesinc.io`.

## Test plan

- [ ] Careers listings show support@wadesinc.io (not careers@wadesplumbing.com)
- [ ] Contact page shows support@wadesinc.io
- [ ] Repo content only contains support@wadesinc.io as a mailbox
- [ ] `npm run ci:content` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

