### PR TITLE
Fix broken end-of-page CTA titles across content pages

### DIFF
--- a/app/service-areas/page.tsx
+++ b/app/service-areas/page.tsx
@@ -50,6 +50,8 @@ export default function ServiceAreasPage() {
 		conversion: normalizeConversion(null, {
 			title: "Plumbing & Septic Service Areas",
 			description,
+			slug: "service-areas",
+			eyebrow: "Local Coverage",
 		}),
 	}
 

--- a/components/content-conversion-cta.tsx
+++ b/components/content-conversion-cta.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next"
 import Link from "next/link"
 import { ArrowRight, BadgeCheck, Clock, Phone, Star } from "lucide-react"
 
@@ -8,9 +9,30 @@ import { cn } from "@/lib/utils"
 
 export function ContentConversionCta({
 	conversion,
+	secondaryAction,
 }: {
 	conversion: ContentConversion
+	/** Override the secondary CTA (defaults to Contact / Get a Free Quote). */
+	secondaryAction?: {
+		href: string
+		label: string
+		external?: boolean
+	}
 }) {
+	const secondary = secondaryAction ?? {
+		href: "/contact",
+		label: "Get a Free Quote",
+		external: false,
+	}
+	const secondaryClassName = cn(
+		buttonVariants({ variant: "inverse", size: "xl" }),
+		"w-full justify-center gap-2 sm:w-auto",
+	)
+	const secondaryIsExternal =
+		secondary.external ||
+		secondary.href.startsWith("mailto:") ||
+		secondary.href.startsWith("tel:")
+
 	return (
 		<section className="surface-dark relative overflow-hidden">
 			<div
@@ -52,17 +74,21 @@ export function ContentConversionCta({
 							<Phone className="size-5" />
 							Call {siteConfig.phone}
 						</a>
-						<Link
-							className={cn(
-								buttonVariants({ variant: "inverse", size: "xl" }),
-								"w-full justify-center gap-2 sm:w-auto",
-							)}
-							href="/contact"
-							prefetch
-						>
-							Get a Free Quote
-							<ArrowRight />
-						</Link>
+						{secondaryIsExternal ? (
+							<a className={secondaryClassName} href={secondary.href}>
+								{secondary.label}
+								<ArrowRight />
+							</a>
+						) : (
+							<Link
+								className={secondaryClassName}
+								href={secondary.href as Route}
+								prefetch
+							>
+								{secondary.label}
+								<ArrowRight />
+							</Link>
+						)}
 					</div>
 
 					<ul className="text-white/70 motion-fade motion-delay-2 mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm font-bold">
@@ -95,38 +121,40 @@ export function ContentConversionCta({
 					</ul>
 				</div>
 
-				<div className="mx-auto mt-14 max-w-5xl">
-					<p className="text-primary-bright mb-6 text-center text-xs font-extrabold tracking-[0.18em] uppercase">
-						What neighbors say
-					</p>
-					<ul className="grid gap-8 md:grid-cols-3 md:gap-10">
-						{conversion.testimonials.map((testimonial, index) => (
-							<li
-								key={`${testimonial.name}-${index}`}
-								className={cn(
-									"motion-rise relative",
-									index === 1 && "motion-delay-1",
-									index >= 2 && "motion-delay-2",
-								)}
-							>
-								<blockquote className="border-white/10 border-t pt-5">
-									<p className="text-[0.95rem] leading-relaxed text-[#e8e8e4]">
-										&ldquo;{testimonial.quote}&rdquo;
-									</p>
-									<footer className="mt-4 text-sm font-extrabold text-white">
-										{testimonial.name}
-										{testimonial.location ? (
-											<span className="text-white/55 font-bold">
-												{" "}
-												· {testimonial.location}
-											</span>
-										) : null}
-									</footer>
-								</blockquote>
-							</li>
-						))}
-					</ul>
-				</div>
+				{conversion.testimonials.length > 0 ? (
+					<div className="mx-auto mt-14 max-w-5xl">
+						<p className="text-primary-bright mb-6 text-center text-xs font-extrabold tracking-[0.18em] uppercase">
+							What neighbors say
+						</p>
+						<ul className="grid gap-8 md:grid-cols-3 md:gap-10">
+							{conversion.testimonials.map((testimonial, index) => (
+								<li
+									key={`${testimonial.name}-${index}`}
+									className={cn(
+										"motion-rise relative",
+										index === 1 && "motion-delay-1",
+										index >= 2 && "motion-delay-2",
+									)}
+								>
+									<blockquote className="border-white/10 border-t pt-5">
+										<p className="text-[0.95rem] leading-relaxed text-[#e8e8e4]">
+											&ldquo;{testimonial.quote}&rdquo;
+										</p>
+										<footer className="mt-4 text-sm font-extrabold text-white">
+											{testimonial.name}
+											{testimonial.location ? (
+												<span className="text-white/55 font-bold">
+													{" "}
+													· {testimonial.location}
+												</span>
+											) : null}
+										</footer>
+									</blockquote>
+								</li>
+							))}
+						</ul>
+					</div>
+				) : null}
 			</div>
 		</section>
 	)

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -2,6 +2,7 @@ import type { Route } from "next"
 
 import type { ContentDocument } from "@/lib/content"
 import { articleJsonLd, breadcrumbJsonLd, webPageJsonLd } from "@/lib/seo"
+import { siteConfig } from "@/lib/site"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentConversionCta } from "@/components/content-conversion-cta"
@@ -72,7 +73,18 @@ export function ContentPage({
 					/>
 				</aside>
 			</article>
-			<ContentConversionCta conversion={document.conversion} />
+			<ContentConversionCta
+				conversion={document.conversion}
+				secondaryAction={
+					document.slug === "contact" || document.slug.startsWith("careers")
+						? {
+								href: `mailto:${siteConfig.email}`,
+								label: "Email Us",
+								external: true,
+							}
+						: undefined
+				}
+			/>
 			<JsonLd
 				data={[
 					isPost ? articleJsonLd(document) : webPageJsonLd(document),

--- a/lib/content-conversion.ts
+++ b/lib/content-conversion.ts
@@ -158,13 +158,171 @@ function parseConversionBundle(
 	}
 }
 
-function fallbackTitle(title: string) {
-	const cleaned = title.replace(/\?$/, "").trim()
-	// Avoid "Ready for help with Ensure Optimal..." when titles already read as CTAs.
-	if (SOFT_CTA_HEADING.test(cleaned) || /^(get|need|want)\b/i.test(cleaned)) {
+export type ConversionFallback = {
+	title: string
+	description: string
+	slug?: string
+	eyebrow?: string
+}
+
+type PageKind =
+	| "career"
+	| "contact"
+	| "about"
+	| "area"
+	| "tip"
+	| "service"
+	| "general"
+
+/** Section headings that should never become the designed CTA title. */
+const WEAK_CONVERSION_TITLE =
+	/^(how to apply|request service|next steps|learn more|get started|contact us|apply now|more information|serving [\w\s,.&'-]+|our office|hours of operation|frequently asked questions|coverage by .+|why .+ matters)$/i
+
+/** Broken template from the old "Get local help with {Page Title}" fallback. */
+const BROKEN_TEMPLATE_TITLE = /^get local help with\b/i
+
+/** Headings that read as intentional end-of-page CTAs written in markdown. */
+const INTENTIONAL_CTA_TITLE =
+	/^(get|need|want|ready|join|call|schedule|act|skip|upgrade|protect|ensure|don'?t|book|trust|choose|clear|stop|fix|replace|install)\b/i
+
+function detectPageKind(fallback: ConversionFallback): PageKind {
+	const slug = (fallback.slug ?? "").toLowerCase()
+	const title = fallback.title.trim().toLowerCase()
+	const eyebrow = (fallback.eyebrow ?? "").toLowerCase()
+	const description = fallback.description.toLowerCase()
+	const haystack = `${slug} ${title} ${eyebrow} ${description}`
+
+	if (
+		slug.startsWith("careers") ||
+		eyebrow === "careers" ||
+		/\b(join our team|job description|how to apply|resume|hiring|equal opportunity employer)\b/.test(
+			haystack,
+		)
+	) {
+		return "career"
+	}
+	if (slug === "contact" || title === "contact us" || title === "contact") {
+		return "contact"
+	}
+	if (
+		slug === "about-us" ||
+		slug.startsWith("about") ||
+		title === "about us" ||
+		/\bour (mission|values|story)\b/.test(haystack)
+	) {
+		return "about"
+	}
+	if (
+		slug.startsWith("service-area") ||
+		slug === "service-areas" ||
+		/\bplumbing\s*&\s*septic services\b/.test(title) ||
+		/\bca plumbing\b/.test(title)
+	) {
+		return "area"
+	}
+	if (
+		/\b(guide|tips?|how to|what is|why |signs |maintenance)\b/.test(title) ||
+		/\bhomeowner\b/.test(haystack)
+	) {
+		return "tip"
+	}
+	// Service offerings and most service-named pages.
+	if (
+		slug.includes("/") === false &&
+		(description.includes("santa cruz") ||
+			/\b(repair|installation|inspection|pumping|cleaning|replacement|septic|plumbing|drain|heater)\b/.test(
+				haystack,
+			))
+	) {
+		return "service"
+	}
+	return "general"
+}
+
+type KindCta = {
+	eyebrow: string
+	title: string
+	description: string
+}
+
+function kindCta(kind: PageKind, fallback: ConversionFallback): KindCta {
+	const pageDescription = fallback.description.trim()
+
+	switch (kind) {
+		case "career":
+			return {
+				eyebrow: "We're hiring",
+				title: "Ready to join the Wade's team?",
+				description:
+					pageDescription ||
+					"Send your resume to support@wadesinc.io with the role you want and the best way to reach you.",
+			}
+		case "contact":
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Ready to schedule service?",
+				description:
+					"Call or text 831.225.4344. We confirm your address, triage the issue, and get you on the schedule.",
+			}
+		case "about":
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Need a local licensed team you can trust?",
+				description:
+					pageDescription ||
+					"Family-owned plumbing and septic specialists. Clear options, honest pricing, and work done the right way.",
+			}
+		case "area":
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Need plumbing or septic help near you?",
+				description:
+					pageDescription ||
+					"Call 831.225.4344 with the property address. We will confirm coverage and the right next step.",
+			}
+		case "tip":
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Need this handled by a pro?",
+				description:
+					"Talk with Wade's for clear options and honest pricing. Call 831.225.4344 or request service online.",
+			}
+		case "service":
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Ready for clear options and honest pricing?",
+				description:
+					pageDescription ||
+					"Call 831.225.4344. A local licensed team will help you decide the right next step before work begins.",
+			}
+		default:
+			return {
+				eyebrow: "Local · Licensed · Responsive",
+				title: "Ready to talk with Wade's?",
+				description:
+					pageDescription ||
+					"Call 831.225.4344 for plumbing and septic help across Santa Cruz County and selected Santa Clara County communities.",
+			}
+	}
+}
+
+function resolveConversionTitle(
+	candidate: string | undefined,
+	kindDefaults: KindCta,
+): string {
+	const cleaned = candidate?.trim() ?? ""
+	if (
+		!cleaned ||
+		WEAK_CONVERSION_TITLE.test(cleaned) ||
+		BROKEN_TEMPLATE_TITLE.test(cleaned)
+	) {
+		return kindDefaults.title
+	}
+	// Keep intentional CTA headlines already written in markdown.
+	if (INTENTIONAL_CTA_TITLE.test(cleaned) || /\btoday\??$/i.test(cleaned)) {
 		return cleaned
 	}
-	return `Get local help with ${cleaned}`
+	return kindDefaults.title
 }
 
 /**
@@ -173,7 +331,7 @@ function fallbackTitle(title: string) {
  */
 export function extractContentConversion(
 	content: string,
-	fallback: { title: string; description: string },
+	fallback: ConversionFallback,
 ): { content: string; conversion: ContentConversion } {
 	const sections = splitH2Sections(content)
 	const removals: Array<{ start: number; end: number }> = []
@@ -229,11 +387,13 @@ export function extractContentConversion(
 		parsedSections.map((section) => section.body).join("\n"),
 	)
 
+	const defaults = kindCta(detectPageKind(fallback), fallback)
+
 	// Testimonials were nested under FAQ with no separate CTA heading.
 	if (!conversion && parsedSections.length > 0) {
 		conversion = {
-			title: fallbackTitle(fallback.title),
-			description: fallback.description.trim(),
+			title: defaults.title,
+			description: defaults.description,
 			testimonials: allQuotes,
 		}
 	} else if (conversion && allQuotes.length > conversion.testimonials.length) {
@@ -248,33 +408,35 @@ export function extractContentConversion(
 
 export function normalizeConversion(
 	conversion: ContentConversion | null | undefined,
-	fallback: { title: string; description: string },
+	fallback: ConversionFallback,
 ): ContentConversion {
-	const title = conversion?.title?.trim() || fallbackTitle(fallback.title)
+	const defaults = kindCta(detectPageKind(fallback), fallback)
+	const rawTitle = conversion?.title?.trim()
+	const titleIsWeak = !rawTitle || WEAK_CONVERSION_TITLE.test(rawTitle)
+	const title = resolveConversionTitle(rawTitle, defaults)
 
+	const rawDescription = conversion?.description?.trim() ?? ""
 	const description =
-		conversion?.description?.trim() ||
-		fallback.description.trim() ||
-		"Talk with a local licensed team for clear options, honest pricing, and work done the right way."
+		!titleIsWeak && rawDescription ? rawDescription : defaults.description
 
 	const testimonials =
 		conversion?.testimonials && conversion.testimonials.length > 0
 			? conversion.testimonials
-			: defaultTestimonialsFor(fallback.title)
+			: defaultTestimonials()
 
 	return {
-		eyebrow: conversion?.eyebrow?.trim() || "Local · Licensed · Responsive",
+		eyebrow: conversion?.eyebrow?.trim() || defaults.eyebrow,
 		title,
 		description,
 		testimonials,
 	}
 }
 
-function defaultTestimonialsFor(topic: string): ContentTestimonial[] {
-	const focus = topic.replace(/\s+/g, " ").trim() || "plumbing and septic work"
+function defaultTestimonials(): ContentTestimonial[] {
 	return [
 		{
-			quote: `Clear communication and solid workmanship. The team made ${focus.toLowerCase()} straightforward from the first call.`,
+			quote:
+				"Clear communication and solid workmanship. The team made the whole job straightforward from the first call.",
 			name: "Sarah",
 			location: "Santa Cruz",
 		},

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -57,9 +57,10 @@ function parseDocument(absolutePath: string, slug: string): ContentDocument {
 	const { data, content } = matter(source)
 	const title = String(data.title ?? slug)
 	const description = String(data.description ?? "")
+	const eyebrow = data.eyebrow ? String(data.eyebrow) : undefined
 	const { content: articleContent, conversion } = extractContentConversion(
 		content,
-		{ title, description },
+		{ title, description, slug, eyebrow },
 	)
 
 	return {
@@ -73,7 +74,7 @@ function parseDocument(absolutePath: string, slug: string): ContentDocument {
 		updated: normalizeDate(data.updated),
 		image: data.image ? String(data.image) : undefined,
 		imageAlt: data.imageAlt ? String(data.imageAlt) : undefined,
-		eyebrow: data.eyebrow ? String(data.eyebrow) : undefined,
+		eyebrow,
 		order: data.order === undefined ? undefined : Number(data.order),
 		featured: Boolean(data.featured),
 		gallery: Array.isArray(data.gallery)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The designed end-of-page conversion CTA used a template title (`Get local help with {Page Title}`). That reads poorly on careers, contact, about, and other non-service pages. Example on Licensed Plumber:

- Title: "Get local help with Licensed Plumber"
- Testimonials that awkwardly inject the job title
- Secondary button "Get a Free Quote" pointing at `/contact` on a hiring page

## Fix

- Detect page kind from slug / eyebrow / copy (`career`, `contact`, `about`, `area`, `tip`, `service`, `general`)
- Use kind-specific CTA titles and eyebrows (careers → "Ready to join the Wade's team?" / "We're hiring")
- Reject the old "Get local help with…" template and other weak section headings
- Keep intentional markdown CTA headlines when they already read as CTAs
- Use generic neighbor testimonials instead of title-injected quotes
- On contact and careers pages, secondary action is **Email Us** (`mailto:support@wadesinc.io`) instead of Free Quote

## Examples

| Page | CTA title |
| --- | --- |
| Careers / Licensed Plumber | Ready to join the Wade's team? |
| Contact | Ready to schedule service? |
| Service areas | Need plumbing or septic help near you? |
| Drain Cleaning (no custom CTA) | Ready for clear options and honest pricing? |
| Service with written CTA | Keeps the markdown headline (e.g. Act Now…) |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

