### PR TITLE
Rebuild home hero as a full-viewport cinematic frame

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -145,6 +145,12 @@
 	   headline → content + service hero h1 (was misusing display)
 	   title    → section h2
 	   subtitle → sub-section h2/h3 (the step that was missing entirely) */
+	/*
+	  Cinematic step, above display. Sized off vw so the headline scales to the
+	  measure of the viewport and reads edge to edge rather than sitting as a
+	  block of text on a photo.
+	*/
+	--type-cinematic: clamp(3.25rem, 13vw, 9rem);
 	--type-display: clamp(2.35rem, 5.4vw, 4.25rem);
 	--type-headline: clamp(1.95rem, 3.6vw, 3rem);
 	--type-title: clamp(1.65rem, 2.6vw, 2.25rem);
@@ -179,6 +185,9 @@
 	--measure: 60ch;
 	--sidebar-w: 20.5rem;
 	--header-offset: 6.5rem;
+	/* Visible header height, used to size the cinematic hero to the viewport.
+	   Matches the 64px bar on phones; the utility bar adds 28px from sm up. */
+	--header-h: 4rem;
 
 	/* Focus-ring offset colour. Surfaces override it so rings never halo
 	   white on ink panels. Consumed by the button/control base classes. */
@@ -234,6 +243,18 @@
 	--dark-1: oklch(0.195 0.008 68);
 	--dark-2: oklch(0.232 0.009 68);
 	--dark-3: oklch(0.268 0.01 68);
+}
+
+/*
+  Must stay unlayered. Declared inside @layer base it lost to the unlayered
+  :root block above, so --header-h stayed at the phone value and the cinematic
+  hero came out 40px taller than the viewport, clipping its bottom bar.
+*/
+@media (width >= 40rem) {
+	:root {
+		/* Utility bar (28px) + main bar (72px) + hairline. */
+		--header-h: 6.5rem;
+	}
 }
 
 /*
@@ -608,6 +629,89 @@
 	}
 
 	/*
+	  Cinematic hero. Sized to the visible viewport minus the header, so the whole
+	  frame is on screen at once instead of being cropped by the sticky bar.
+
+	  svh, not vh or dvh: vh ignores mobile browser chrome and overflows, dvh
+	  changes as the URL bar hides and makes the headline resize while you scroll.
+	  svh is the small (chrome-visible) viewport, which is stable.
+	*/
+	.hero-cinematic {
+		--border: color-mix(in srgb, white 12%, transparent);
+		--muted-foreground: var(--on-dark-muted);
+		--ring-offset: oklch(0 0 0);
+		position: relative;
+		isolation: isolate;
+		display: flex;
+		flex-direction: column;
+		min-height: calc(100svh - var(--header-h));
+		overflow: clip;
+		background: var(--ink);
+		color: var(--on-dark);
+	}
+
+	/*
+	  Bottom-weighted scrim. Two stops rather than a flat overlay: the top of the
+	  frame stays open so the photograph reads as a photograph, and the weight
+	  gathers only where the type sits.
+	*/
+	.hero-cinematic::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		pointer-events: none;
+		background:
+			linear-gradient(
+				to top,
+				oklch(0 0 0 / 0.88) 0%,
+				oklch(0 0 0 / 0.62) 26%,
+				oklch(0 0 0 / 0.18) 58%,
+				oklch(0 0 0 / 0.32) 100%
+			),
+			linear-gradient(to right, oklch(0 0 0 / 0.45) 0%, transparent 55%);
+	}
+
+	/*
+	  Slow drift on the hero photograph. Cinematic movement comes from the frame,
+	  not from elements sliding in, so this is the only motion in the band.
+	*/
+	.media-drift {
+		will-change: transform;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.media-drift {
+			animation: drift 28s ease-in-out infinite alternate;
+		}
+	}
+
+	/* Scroll cue: a hairline that pulses down the page. */
+	.scroll-cue {
+		position: relative;
+		display: block;
+		width: 1px;
+		height: 1.75rem;
+		overflow: hidden;
+		background: color-mix(in srgb, white 18%, transparent);
+	}
+
+	.scroll-cue::after {
+		content: "";
+		position: absolute;
+		inset-inline: 0;
+		top: 0;
+		height: 45%;
+		background: var(--primary-bright);
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.scroll-cue::after {
+			animation: cue 2.4s cubic-bezier(0.65, 0, 0.35, 1) infinite;
+		}
+	}
+
+	/*
 	  Floating dark panel: mega menu, popovers. --dark-2 with a full hairline and
 	  a real drop shadow, so it reads as sitting above the page rather than being
 	  cut out of the header.
@@ -713,6 +817,7 @@
 	}
 
 	/* Type */
+	.type-cinematic,
 	.type-display,
 	.type-headline,
 	.type-title,
@@ -730,12 +835,25 @@
 	  headings keep their normal half-leading.
 	*/
 	@supports (text-box: trim-both cap alphabetic) {
+		.type-cinematic,
 		.type-display,
 		.type-headline,
 		.type-title,
 		.type-subtitle {
 			text-box: trim-both cap alphabetic;
 		}
+	}
+
+	/*
+	  Cinematic headline. Very tight leading and negative tracking so stacked
+	  lines lock into a single mass, the way a title card does. text-wrap is left
+	  alone here: at this size the line breaks are authored with <br>, and balance
+	  would fight them.
+	*/
+	.type-cinematic {
+		font-size: var(--type-cinematic);
+		line-height: 0.9;
+		letter-spacing: -0.045em;
 	}
 
 	.type-display {
@@ -995,6 +1113,26 @@
 	}
 	to {
 		height: 0;
+	}
+}
+
+/* Ken Burns drift on the hero frame. */
+@keyframes drift {
+	from {
+		transform: scale(1.06) translate3d(0, 0, 0);
+	}
+	to {
+		transform: scale(1.16) translate3d(-1.5%, -1.5%, 0);
+	}
+}
+
+@keyframes cue {
+	0% {
+		transform: translateY(-100%);
+	}
+	60%,
+	100% {
+		transform: translateY(340%);
 	}
 }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -189,16 +189,23 @@ const faqs = [
 ]
 
 /*
- * Art-directed pair: a landscape crop for the framed plate on wide screens, a
- * shorter crop on phones. `sizes` reflects the framed column (about 45vw from lg
- * up) rather than the old full-bleed 100vw, so the browser stops fetching a
- * viewport-width file for a half-width slot.
+ * Art direction for the cinematic frame. The viewport is landscape on desktop
+ * and portrait on a phone, so the two orientations get different photographs
+ * rather than one image cropped badly at both ends.
+ *
+ * Desktop is the blue-hour rough-in: 1280px wide against a 1440px band, so it
+ * upscales ~1.1x and stays sharp. The old pairing had this backwards, serving a
+ * 768x1024 portrait to desktop (a 1.9x upscale) and a 640x400 landscape to
+ * phones.
+ *
+ * One alt for both sources, since <picture> has a single <img>: it has to be
+ * true of whichever photograph is served.
  */
-const HERO_SIZES = "(min-width: 1024px) 45vw, (min-width: 640px) 90vw, 100vw"
+const HERO_SIZES = "100vw"
 
 function HomeHeroMedia() {
 	const common = {
-		alt: "Three-tank engineered septic system installed on a hillside property in Santa Cruz County",
+		alt: "Recent Wade's Plumbing & Septic work on a Santa Cruz County property",
 		sizes: HERO_SIZES,
 	} as const
 
@@ -206,20 +213,20 @@ function HomeHeroMedia() {
 		props: { srcSet: desktop },
 	} = getImageProps({
 		...common,
-		width: 900,
-		height: 720,
-		quality: 72,
-		src: "/images/work/engineered-septic-hero.webp",
+		width: 1280,
+		height: 961,
+		quality: 74,
+		src: "/images/team/byron-working.webp",
 	})
 
 	const {
-		props: { srcSet: mobile, ...rest },
+		props: { srcSet: portrait, ...rest },
 	} = getImageProps({
 		...common,
-		width: 640,
-		height: 480,
-		quality: 68,
-		src: "/images/work/engineered-septic-hero-mobile.webp",
+		width: 768,
+		height: 1024,
+		quality: 70,
+		src: "/images/work/engineered-septic-hero.webp",
 	})
 
 	return (
@@ -227,9 +234,9 @@ function HomeHeroMedia() {
 			<source media="(min-width: 640px)" srcSet={desktop} sizes={HERO_SIZES} />
 			<img
 				{...rest}
-				srcSet={mobile}
+				srcSet={portrait}
 				alt={common.alt}
-				className="absolute inset-0 size-full object-cover object-center"
+				className="absolute inset-0 size-full object-cover object-[50%_62%]"
 				decoding="async"
 				fetchPriority="high"
 			/>
@@ -241,32 +248,48 @@ export default function HomePage() {
 	return (
 		<main id="main-content">
 			{/*
-			  The photo used to be a full-bleed background under three stacked
-			  scrims, which flattened the best asset on the site into grey mush and
-			  left the copy floating on an empty field.
+			  Cinematic frame. Full-bleed work photograph sized to the visible
+			  viewport, with the headline set at --type-cinematic and anchored low so
+			  the picture carries the top of the frame and the type carries the
+			  bottom. Structure follows the pattern used by Lightship and Locomotive:
+			  minimal chrome, one oversized statement, credentials pinned to the
+			  bottom edge as a hairline bar.
 
-			  It is now a framed object in its own column: a spec plate, captioned
-			  the way a permit photo is, with the job's real numbers under it. The
-			  copy column keeps the ink and textures, so the two halves read as
-			  "pitch" and "proof" instead of "text on a picture".
+			  The photograph is the argument here, so it is not boxed, tinted, or
+			  reduced to texture. Only motion in the band is the slow drift on the
+			  frame itself.
 			*/}
-			<section className="surface-hero tex-grid tex-glow overflow-hidden">
-				<div className="container-shell grid items-center gap-10 pt-16 pb-14 sm:pt-20 sm:pb-16 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)] lg:gap-14 lg:pt-24 lg:pb-20">
-					<div>
-						<div className="section-head max-w-xl">
-							<p className="spec-label motion-fade">Santa Cruz County, CA</p>
-							<h1 className="type-display motion-rise text-white">
-								Honest plumbing
-								<br />
-								<span className="text-primary-bright">&amp; septic</span>
-							</h1>
-							<p className="motion-rise motion-delay-1 type-lead text-on-dark-muted">
-								No sales pressure. No upselling. Clear pricing before work
-								begins from local licensed professionals.
-							</p>
-						</div>
+			<section className="hero-cinematic">
+				<div className="absolute inset-0 -z-20">
+					<div className="media-drift relative size-full">
+						<HomeHeroMedia />
+					</div>
+				</div>
 
-						<div className="motion-rise motion-delay-2 mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+				{/* Top line: where we are, and the scroll cue's counterpart. */}
+				<div className="container-shell relative flex items-start justify-between gap-6 pt-8 sm:pt-10">
+					<p className="spec-label motion-fade text-primary-bright">
+						Santa Cruz County, CA
+					</p>
+					<p className="text-on-dark-subtle motion-fade hidden font-mono text-[0.6875rem] tracking-[0.14em] uppercase sm:block">
+						Est. family owned
+					</p>
+				</div>
+
+				<div className="container-shell relative mt-auto pb-8 sm:pb-10">
+					<h1 className="type-cinematic motion-rise text-white">
+						Honest plumbing
+						<br />
+						<span className="text-primary-bright">&amp; septic</span>
+					</h1>
+
+					<div className="motion-rise motion-delay-1 mt-8 flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+						<p className="type-lead text-on-dark-muted max-w-md">
+							No sales pressure. No upselling. Clear pricing before work begins
+							from local licensed professionals.
+						</p>
+
+						<div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
 							<a
 								className={cn(
 									buttonVariants({ size: "xl" }),
@@ -289,53 +312,35 @@ export default function HomePage() {
 								<ArrowRight aria-hidden="true" />
 							</Link>
 						</div>
+					</div>
+				</div>
 
-						{/* Credentials as data, not as another row of chips. */}
-						<dl className="motion-fade motion-delay-2 mt-10 flex flex-wrap gap-x-8 gap-y-4 border-t border-white/10 pt-6">
+				{/*
+				  Credential bar on the bottom edge. Keeps the licence numbers in the
+				  first frame without adding another row of chips, and gives the
+				  photograph a hard bottom rule to sit on.
+				*/}
+				<div className="relative border-t border-white/12 bg-black/35 backdrop-blur-sm">
+					<div className="container-shell flex items-center justify-between gap-6 py-3.5">
+						<dl className="flex flex-wrap items-center gap-x-7 gap-y-1.5">
 							{heroStats.map(({ label, value }) => (
-								<div key={label}>
-									<dt className="text-on-dark-subtle font-mono text-[0.6875rem] tracking-[0.14em] uppercase">
+								<div className="flex items-baseline gap-2" key={label}>
+									<dt className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
 										{label}
 									</dt>
-									<dd className="font-display mt-1 text-[0.9375rem] font-bold tracking-[-0.01em] text-white">
+									<dd className="text-[0.8125rem] font-bold text-white">
 										{value}
 									</dd>
 								</div>
 							))}
 						</dl>
-					</div>
-
-					<figure className="motion-rise motion-delay-1 relative">
-						{/* Copper bloom behind the plate, so it lifts off the band. */}
-						<div
+						{/* Centred in the bar, not hanging below it, where overflow: clip
+						    cut it off and it read as a stray hairline. */}
+						<span
 							aria-hidden="true"
-							className="bg-primary/25 absolute -inset-6 -z-10 rounded-full blur-3xl"
+							className="scroll-cue hidden shrink-0 self-center lg:block"
 						/>
-						<div className="surface-raised overflow-hidden rounded-xl p-2">
-							<div className="relative aspect-4/3 overflow-hidden rounded-lg lg:aspect-5/4">
-								<HomeHeroMedia />
-								<span className="surface-float absolute top-3 left-3 rounded-md px-2.5 py-1.5 font-mono text-[0.625rem] tracking-[0.14em] text-white uppercase backdrop-blur-sm">
-									Engineered ATU
-								</span>
-							</div>
-							<figcaption className="flex items-end justify-between gap-4 px-2 pt-3 pb-1">
-								<span className="text-[0.8125rem] leading-snug font-bold text-white">
-									Three-tank engineered septic system
-									<span className="text-on-dark-subtle block font-normal">
-										Hillside property, Santa Cruz Mountains
-									</span>
-								</span>
-								<Link
-									className="text-primary-bright inline-flex shrink-0 items-center gap-1.5 text-[0.8125rem] font-bold"
-									href="/service-category/septic"
-									prefetch
-								>
-									Septic work
-									<ArrowRight aria-hidden="true" className="size-3.5" />
-								</Link>
-							</figcaption>
-						</div>
-					</figure>
+					</div>
 				</div>
 			</section>
 
@@ -421,16 +426,43 @@ export default function HomePage() {
 								</Link>
 							</div>
 						</div>
-						<div className="bg-muted relative aspect-4/3 overflow-hidden rounded-lg lg:aspect-auto lg:min-h-[26rem]">
-							<Image
-								alt="Three-tank septic system installation on hillside property"
-								className="object-cover"
-								fill
-								quality={70}
-								sizes="(min-width: 1024px) 45vw, 100vw"
-								src="/images/work/completed-multi-tank.webp"
-							/>
-						</div>
+						{/*
+						  The spec-plate treatment lives here now that the hero is a
+						  full-bleed frame. A captioned, framed photo still earns its place
+						  next to the capability list, where it reads as evidence for the
+						  claims beside it.
+						*/}
+						<figure className="surface-panel flex flex-col overflow-hidden p-2">
+							<div className="bg-muted relative aspect-4/3 overflow-hidden rounded-md lg:aspect-auto lg:min-h-[24rem] lg:flex-1">
+								<Image
+									alt="Completed three-tank septic system installation on a hillside property"
+									className="object-cover"
+									fill
+									quality={70}
+									sizes="(min-width: 1024px) 45vw, 100vw"
+									src="/images/work/completed-multi-tank.webp"
+								/>
+								<span className="bg-ink/80 absolute top-3 left-3 rounded-md px-2.5 py-1.5 font-mono text-[0.625rem] tracking-[0.14em] text-white uppercase backdrop-blur-sm">
+									Engineered ATU
+								</span>
+							</div>
+							<figcaption className="flex items-end justify-between gap-4 px-2 pt-3 pb-1">
+								<span className="text-[0.8125rem] leading-snug font-bold">
+									Three-tank engineered septic system
+									<span className="text-muted-foreground block font-normal">
+										Hillside property, Santa Cruz Mountains
+									</span>
+								</span>
+								<Link
+									className="text-primary inline-flex shrink-0 items-center gap-1.5 text-[0.8125rem] font-bold"
+									href="/service-category/septic"
+									prefetch
+								>
+									Septic work
+									<ArrowRight aria-hidden="true" className="size-3.5" />
+								</Link>
+							</figcaption>
+						</figure>
 					</div>
 				</div>
 			</section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebuilds the homepage hero into a full-viewport cinematic frame: full-bleed photograph, oversized type anchored low, and credentials as a bottom hairline bar. The previous layout read as a boxed photo beside a column of copy.

## What changed

- **Frame:** `calc(100svh - var(--header-h))` so the whole hero fits under the sticky header; uses `svh` for stable mobile sizing
- **Type:** new `--type-cinematic` step (`clamp(3.25rem, 13vw, 9rem)`) for an edge-to-edge headline
- **Photo:** art-directed desktop/phone sources (correct orientation pairing), bottom-weighted scrim, slow Ken Burns drift (respects `prefers-reduced-motion`)
- **Credentials:** license/stats bar on the bottom edge with scroll cue
- **Specialty section:** framed “spec plate” photo treatment moves here as evidence beside the capability list

## Files

- `app/page.tsx`
- `app/globals.css`

Branch is already based on current `main` and merges cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

