### PR TITLE
Polish secondary surfaces to match the redesign

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -19,37 +19,38 @@ export default function Error({
 	}, [error])
 
 	return (
-		<main
-			className="container-shell grid min-h-[60vh] place-items-center py-[var(--space-section-y)]"
-			id="main-content"
-		>
-			<div className="section-head max-w-xl text-center" role="alert">
-				<p className="spec-label spec-label-center">Something went wrong</p>
-				<h1 className="type-headline">We hit an unexpected error.</h1>
-				<p className="type-lead">
-					Try again, or head home and keep browsing. If this keeps happening,
-					give us a call and we will help.
-				</p>
-				<div className="flex flex-col justify-center gap-3 pt-3 sm:flex-row">
-					<button
-						className={cn(buttonVariants({ size: "lg" }), "w-full sm:w-auto")}
-						onClick={reset}
-						type="button"
-					>
-						<RotateCcw aria-hidden="true" />
-						Try again
-					</button>
-					<Link
-						className={cn(
-							buttonVariants({ variant: "outline", size: "lg" }),
-							"w-full sm:w-auto",
-						)}
-						href="/"
-						prefetch
-					>
-						<ArrowLeft aria-hidden="true" />
-						Back home
-					</Link>
+		<main className="surface-hero tex-grid" id="main-content">
+			<div className="container-shell grid min-h-[60vh] place-items-center py-[var(--space-section-y)]">
+				<div className="section-head max-w-xl text-center" role="alert">
+					<p className="spec-label spec-label-center">Something went wrong</p>
+					<h1 className="type-headline text-white">
+						We hit an unexpected error.
+					</h1>
+					<p className="type-lead text-on-dark-muted">
+						Try again, or head home and keep browsing. If this keeps happening,
+						give us a call and we will help.
+					</p>
+					<div className="flex flex-col justify-center gap-3 pt-3 sm:flex-row">
+						<button
+							className={cn(buttonVariants({ size: "lg" }), "w-full sm:w-auto")}
+							onClick={reset}
+							type="button"
+						>
+							<RotateCcw aria-hidden="true" />
+							Try again
+						</button>
+						<Link
+							className={cn(
+								buttonVariants({ variant: "inverse", size: "lg" }),
+								"w-full sm:w-auto",
+							)}
+							href="/"
+							prefetch
+						>
+							<ArrowLeft aria-hidden="true" />
+							Back home
+						</Link>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -7,36 +7,37 @@ import { cn } from "@/lib/utils"
 
 export default function NotFound() {
 	return (
-		<main
-			className="container-shell grid min-h-[60vh] place-items-center py-[var(--space-section-y)]"
-			id="main-content"
-		>
-			<div className="section-head max-w-xl text-center">
-				<p className="spec-label spec-label-center">Error 404</p>
-				<h1 className="type-headline">This page could not be found.</h1>
-				<p className="type-lead">
-					The page may have moved during our website upgrade. Use the links
-					below or call us and we will point you in the right direction.
-				</p>
-				<div className="flex flex-col justify-center gap-3 pt-3 sm:flex-row">
-					<Link
-						className={cn(buttonVariants({ size: "lg" }), "w-full sm:w-auto")}
-						href="/"
-						prefetch
-					>
-						<ArrowLeft aria-hidden="true" />
-						Back home
-					</Link>
-					<a
-						className={cn(
-							buttonVariants({ variant: "outline", size: "lg" }),
-							"w-full sm:w-auto",
-						)}
-						href={siteConfig.phoneHref}
-					>
-						<Phone aria-hidden="true" />
-						{siteConfig.phone}
-					</a>
+		<main className="surface-hero tex-grid" id="main-content">
+			<div className="container-shell grid min-h-[60vh] place-items-center py-[var(--space-section-y)]">
+				<div className="section-head max-w-xl text-center">
+					<p className="spec-label spec-label-center">Error 404</p>
+					<h1 className="type-headline text-white">
+						This page could not be found.
+					</h1>
+					<p className="type-lead text-on-dark-muted">
+						The page may have moved during our website upgrade. Use the links
+						below or call us and we will point you in the right direction.
+					</p>
+					<div className="flex flex-col justify-center gap-3 pt-3 sm:flex-row">
+						<Link
+							className={cn(buttonVariants({ size: "lg" }), "w-full sm:w-auto")}
+							href="/"
+							prefetch
+						>
+							<ArrowLeft aria-hidden="true" />
+							Back home
+						</Link>
+						<a
+							className={cn(
+								buttonVariants({ variant: "inverse", size: "lg" }),
+								"w-full sm:w-auto",
+							)}
+							href={siteConfig.phoneHref}
+						>
+							<Phone aria-hidden="true" />
+							{siteConfig.phone}
+						</a>
+					</div>
 				</div>
 			</div>
 		</main>

--- a/app/service-areas/page.tsx
+++ b/app/service-areas/page.tsx
@@ -1,20 +1,16 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { MapPinned, Phone } from "@/components/icons"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
 import { ServiceAreasMap } from "@/components/service-areas-map"
-import { Badge } from "@/components/ui/badge"
-import { buttonVariants } from "@/components/ui/button"
 import type { ContentDocument } from "@/lib/content"
 import { normalizeConversion } from "@/lib/content-conversion"
 import { locationsByCounty, serviceAreaLocations } from "@/lib/service-areas"
 import { breadcrumbJsonLd, buildPageMetadata, webPageJsonLd } from "@/lib/seo"
 import { siteConfig } from "@/lib/site"
-import { cn } from "@/lib/utils"
 
 const description =
 	"Interactive map of Wade's Plumbing & Septic coverage across Santa Cruz County and the mountain foothills into Los Gatos and Saratoga, generally west of Highway 101."
@@ -67,13 +63,13 @@ export default function ServiceAreasPage() {
 
 			<section className="section-y overflow-x-clip">
 				<div className="container-shell">
-					<div className="mx-auto max-w-3xl text-center">
-						<Badge>Coverage Map</Badge>
-						<h2 className="type-title mt-5">
+					<div className="section-head reveal mx-auto max-w-3xl text-center">
+						<p className="spec-label spec-label-center">Coverage map</p>
+						<h2 className="type-title">
 							See where Wade&apos;s{" "}
 							<span className="text-primary">serves on the Central Coast</span>
 						</h2>
-						<p className="type-lead mt-5">
+						<p className="type-lead">
 							Mountain roads, coastal soils, older piping, steep lots, and
 							septic regulations change how a job should be diagnosed. The map
 							shows our approximate coverage: Santa Cruz County and the west
@@ -84,7 +80,7 @@ export default function ServiceAreasPage() {
 				</div>
 
 				{/* Full-bleed on mobile; map component constrains itself from md up. */}
-				<div className="mt-10">
+				<div className="mt-[var(--space-block)]">
 					<ServiceAreasMap />
 				</div>
 
@@ -100,25 +96,23 @@ export default function ServiceAreasPage() {
 				</p>
 			</section>
 
-			<section className="border-border bg-card border-y">
-				<div className="container-shell section-y space-y-16">
+			<section className="surface-sunken border-border border-y">
+				<div className="container-shell section-y space-y-[var(--space-block)]">
 					{counties.map((county) => (
-						<div key={county.title}>
-							<div className="max-w-3xl">
+						<div className="reveal" key={county.title}>
+							<div className="section-head max-w-3xl">
+								<p className="spec-label">County coverage</p>
 								<h2 className="type-title">{county.title}</h2>
-								<p className="type-lead mt-4">{county.summary}</p>
+								<p className="type-lead">{county.summary}</p>
 							</div>
-							<ul className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+							<ul className="mt-8 grid gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-2 lg:grid-cols-3">
 								{county.locations.map((location) => (
 									<li key={location.slug}>
 										<Link
-											className="border-border bg-background hover:border-primary/40 flex items-center gap-4 rounded-lg border px-5 py-4 text-base font-bold tracking-[-0.02em] transition-colors"
+											className="bg-background hover:bg-muted flex h-full items-center px-5 py-4 text-base font-bold tracking-[-0.02em] transition-colors"
 											href={location.href as Route}
 											prefetch
 										>
-											<span className="bg-accent text-accent-foreground grid size-10 shrink-0 place-items-center rounded-md">
-												<MapPinned className="size-5" aria-hidden="true" />
-											</span>
 											{location.name}
 										</Link>
 									</li>
@@ -129,24 +123,10 @@ export default function ServiceAreasPage() {
 				</div>
 			</section>
 
-			<section className="container-shell section-y">
-				<div className="surface-panel mx-auto max-w-3xl p-8 text-center sm:p-10">
-					<h2 className="type-title">Not sure if we cover your address?</h2>
-					<p className="type-lead mt-4">
-						Call with the city, ZIP code, and type of work. A real person will
-						confirm coverage and schedule the right visit.
-					</p>
-					<a
-						className={cn(buttonVariants({ size: "xl" }), "mt-7 gap-2")}
-						href={siteConfig.phoneHref}
-					>
-						<Phone className="size-5" />
-						Call {siteConfig.phone}
-					</a>
-				</div>
-			</section>
-
-			<ContactCta />
+			<ContactCta
+				description="Call with the city, ZIP code, and type of work. A real person will confirm coverage and schedule the right visit."
+				title="Not sure if we cover your address?"
+			/>
 			<JsonLd
 				data={[
 					webPageJsonLd(document),

--- a/components/content-conversion-cta.tsx
+++ b/components/content-conversion-cta.tsx
@@ -1,6 +1,6 @@
 import type { Route } from "next"
 import Link from "next/link"
-import { ArrowRight, BadgeCheck, Clock, Phone, Star } from "@/components/icons"
+import { ArrowRight, Phone } from "@/components/icons"
 
 import { buttonVariants } from "@/components/ui/button"
 import type { ContentConversion } from "@/lib/content-conversion"
@@ -37,15 +37,15 @@ export function ContentConversionCta({
 		<section className="surface-hero tex-grid tex-glow overflow-hidden">
 			<div className="container-shell section-y relative">
 				<div className="mx-auto max-w-3xl text-center">
-					<p className="spec-label spec-label-center reveal">
-						{conversion.eyebrow}
-					</p>
-					<h2 className="type-title reveal mt-4 text-white">
-						{conversion.title}
-					</h2>
-					<p className="type-lead reveal text-on-dark-muted mx-auto mt-5 max-w-2xl">
-						{conversion.description}
-					</p>
+					<div className="section-head reveal items-center text-center">
+						<p className="spec-label spec-label-center">
+							{conversion.eyebrow}
+						</p>
+						<h2 className="type-title text-white">{conversion.title}</h2>
+						<p className="type-lead text-on-dark-muted mx-auto max-w-2xl">
+							{conversion.description}
+						</p>
+					</div>
 
 					<div className="reveal mt-8 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
 						<a
@@ -58,7 +58,7 @@ export function ContentConversionCta({
 						{secondaryIsExternal ? (
 							<a className={secondaryClassName} href={secondary.href}>
 								{secondary.label}
-								<ArrowRight />
+								<ArrowRight aria-hidden="true" />
 							</a>
 						) : (
 							<Link
@@ -67,42 +67,10 @@ export function ContentConversionCta({
 								prefetch
 							>
 								{secondary.label}
-								<ArrowRight />
+								<ArrowRight aria-hidden="true" />
 							</Link>
 						)}
 					</div>
-
-					<ul className="text-on-dark-muted reveal mt-8 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm font-bold">
-						<li className="inline-flex items-center gap-2">
-							<span
-								className="text-primary-bright inline-flex items-center gap-0.5"
-								aria-label="5 star rated"
-							>
-								{Array.from({ length: 5 }).map((_, index) => (
-									<Star
-										className="size-3.5 fill-current"
-										key={index}
-										aria-hidden="true"
-									/>
-								))}
-							</span>
-							5-star local reviews
-						</li>
-						<li className="inline-flex items-center gap-2">
-							<BadgeCheck
-								className="text-primary-bright size-4"
-								aria-hidden="true"
-							/>
-							{siteConfig.licenses}
-						</li>
-						<li className="inline-flex items-center gap-2">
-							<Clock
-								className="text-primary-bright size-4"
-								aria-hidden="true"
-							/>
-							{siteConfig.hours}
-						</li>
-					</ul>
 				</div>
 
 				{conversion.testimonials.length > 0 ? (
@@ -110,8 +78,6 @@ export function ContentConversionCta({
 						<p className="spec-label spec-label-center mb-7">
 							What neighbors say
 						</p>
-						{/* No manual delays: scroll-driven reveals stagger on their own,
-						    since each column crosses the viewport edge in turn. */}
 						<ul className="grid gap-8 md:grid-cols-3 md:gap-10">
 							{conversion.testimonials.map((testimonial, index) => (
 								<li
@@ -137,6 +103,25 @@ export function ContentConversionCta({
 						</ul>
 					</div>
 				) : null}
+			</div>
+
+			{/*
+			  Credential bar mirrors the home cinematic hero: one hairline row
+			  instead of a wrap cluster of stars and chips.
+			*/}
+			<div className="relative border-t border-white/12 bg-black/25">
+				<div className="container-shell flex flex-wrap items-center justify-center gap-x-7 gap-y-2 py-3.5 sm:justify-between">
+					<p className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
+						<span className="text-primary-bright">★★★★★</span>
+						<span className="ml-2 text-white/85">5-star local reviews</span>
+					</p>
+					<p className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
+						{siteConfig.licenses}
+					</p>
+					<p className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
+						{siteConfig.hours}
+					</p>
+				</div>
 			</div>
 		</section>
 	)

--- a/components/filterable-archive.tsx
+++ b/components/filterable-archive.tsx
@@ -7,7 +7,6 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import { ArrowLeft, ArrowRight, CalendarDays } from "@/components/icons"
 import { startTransition, useEffect, useMemo } from "react"
 
-import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
 import {
 	Card,
@@ -98,7 +97,7 @@ function ArchiveCard({
 	 * card's own container width - see `@container card` in globals.css.
 	 */
 	return (
-		<Card className="group hover:border-primary/40 h-full overflow-hidden transition-[border-color,transform] duration-200 hover:-translate-y-0.5">
+		<Card className="group hover:border-border-strong h-full overflow-hidden transition-colors duration-200">
 			<Link
 				aria-label={
 					variant === "service" ? `View ${item.title}` : `Read ${item.title}`
@@ -118,7 +117,7 @@ function ArchiveCard({
 				/>
 			</Link>
 			<CardHeader>
-				<Badge tone="muted">{item.category}</Badge>
+				<p className="spec-tag">{item.category}</p>
 				<CardTitle className="group-hover:text-primary mt-2.5 transition-colors">
 					<Link href={item.href as Route} prefetch={false}>
 						{item.title}

--- a/components/global-search.tsx
+++ b/components/global-search.tsx
@@ -127,8 +127,8 @@ function ResultCard({
 				className={cn(
 					"relative min-h-[5.5rem] sm:min-h-[7rem]",
 					hit.image
-						? "bg-[#1c2025]"
-						: "bg-[color-mix(in_srgb,var(--primary)_22%,#1c2025)] text-[var(--primary-bright)]",
+						? "bg-dark-2"
+						: "bg-[color-mix(in_srgb,var(--primary)_22%,var(--dark-2))] text-[var(--primary-bright)]",
 				)}
 			>
 				{hit.image ? (
@@ -304,11 +304,7 @@ export function GlobalSearch({
 			>
 				<div
 					aria-hidden
-					className="pointer-events-none absolute inset-0"
-					style={{
-						background:
-							"radial-gradient(900px 420px at 12% -8%, color-mix(in srgb, var(--primary) 22%, transparent), transparent 58%), radial-gradient(700px 360px at 92% 8%, color-mix(in srgb, var(--primary-bright) 10%, transparent), transparent 52%), linear-gradient(180deg, #14181d 0%, #101214 48%, #0d1013 100%)",
-					}}
+					className="tex-glow pointer-events-none absolute inset-0 bg-ink"
 				/>
 
 				<div className="relative flex h-full min-h-0 flex-col">
@@ -371,7 +367,7 @@ export function GlobalSearch({
 							</label>
 
 							<div className="mt-3 flex items-center justify-between gap-3">
-								<div className="flex min-w-0 flex-1 [scrollbar-width:none] gap-2 overflow-x-auto [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+								<div className="chip-rail min-w-0 flex-1">
 									{suggestions.map((suggestion) => (
 										<button
 											key={suggestion}
@@ -381,7 +377,7 @@ export function GlobalSearch({
 												setActiveIndex(0)
 												inputRef.current?.focus()
 											}}
-											className="text-on-dark-muted shrink-0 rounded-md bg-white/[0.05] px-3 py-1.5 text-xs font-bold transition-colors duration-75 hover:bg-white/[0.09] hover:text-white"
+											className="spec-tag text-on-dark-muted hover:text-primary-bright shrink-0 border border-white/10 bg-white/[0.04] px-3 py-1.5 transition-colors duration-75 hover:border-white/20 hover:bg-white/[0.07]"
 										>
 											{suggestion}
 										</button>
@@ -416,11 +412,11 @@ export function GlobalSearch({
 							) : null}
 
 							{showEmpty ? (
-								<div className="mx-auto max-w-lg py-14 text-center">
-									<p className="font-display text-2xl font-extrabold tracking-[-0.03em] text-white">
+								<div className="section-head mx-auto max-w-lg py-14 text-center">
+									<p className="type-title text-white">
 										Nothing for “{query.trim()}”
 									</p>
-									<p className="mt-2 text-sm text-white/50">
+									<p className="type-lead text-on-dark-muted">
 										Try a symptom, city, or service name. Typos are OK; we
 										surface the closest matches when we can.
 									</p>

--- a/components/related-content.tsx
+++ b/components/related-content.tsx
@@ -6,7 +6,6 @@ import { ArrowRight } from "@/components/icons"
 import type { ArchiveItem } from "@/lib/archive"
 import type { RelatedContent } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
-import { Badge } from "@/components/ui/badge"
 
 function RelatedCard({
 	item,
@@ -21,7 +20,7 @@ function RelatedCard({
 			: (item.image ?? "/images/work/precision-valve-installation.webp")
 
 	return (
-		<article className="group surface-panel flex h-full flex-col overflow-hidden">
+		<article className="group surface-panel reveal flex h-full flex-col overflow-hidden">
 			<Link
 				aria-label={
 					variant === "service" ? `View ${item.title}` : `Read ${item.title}`
@@ -40,11 +39,9 @@ function RelatedCard({
 					src={image}
 				/>
 			</Link>
-			<div className="flex flex-1 flex-col gap-3 p-[var(--space-card)]">
-				<Badge className="w-fit" tone="muted">
-					{item.category}
-				</Badge>
-				<h3 className="type-subtitle text-[1.0625rem] transition-colors group-hover:text-primary">
+			<div className="card-head flex flex-col gap-3">
+				<p className="spec-tag">{item.category}</p>
+				<h3 className="card-title font-bold tracking-[-0.02em] transition-colors group-hover:text-primary">
 					<Link href={item.href as Route} prefetch={false}>
 						{item.title}
 					</Link>
@@ -52,8 +49,10 @@ function RelatedCard({
 				<p className="text-muted-foreground line-clamp-2 text-sm leading-relaxed">
 					{item.description}
 				</p>
+			</div>
+			<div className="card-body">
 				<Link
-					className="text-primary mt-auto inline-flex items-center gap-2 text-sm font-bold"
+					className="text-primary inline-flex items-center gap-2 text-sm font-bold"
 					href={item.href as Route}
 					prefetch={false}
 				>
@@ -85,8 +84,11 @@ function RelatedGroup({
 
 	return (
 		<div>
-			<div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-				<h2 className="type-title text-2xl sm:text-3xl">{title}</h2>
+			<div className="section-head-row mb-8">
+				<div className="section-head">
+					<p className="spec-label">Keep exploring</p>
+					<h2 className="type-title">{title}</h2>
+				</div>
 				<Link
 					className="text-primary inline-flex items-center gap-2 text-sm font-bold"
 					href={viewAllHref}
@@ -96,7 +98,7 @@ function RelatedGroup({
 					<ArrowRight aria-hidden="true" className="size-4" />
 				</Link>
 			</div>
-			<div className="grid gap-[var(--space-grid)] md:grid-cols-2 xl:grid-cols-3">
+			<div className="card-rail">
 				{items.map((item) => (
 					<RelatedCard item={item} key={item.slug} variant={variant} />
 				))}
@@ -117,7 +119,7 @@ export function RelatedContentSections({
 	if (!related.services.length && !related.posts.length) return null
 
 	return (
-		<section className="border-border bg-secondary/35 border-y">
+		<section className="surface-sunken border-border border-y">
 			<div className="container-shell section-y space-y-[var(--space-block)]">
 				<RelatedGroup
 					items={related.services}

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -6,7 +6,6 @@ import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
 import { MarkdownContent } from "@/components/markdown-content"
 import { RelatedContentSections } from "@/components/related-content"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import type { ContentDocument } from "@/lib/content"
 import type { RelatedContent } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
@@ -65,7 +64,7 @@ export function ServiceLandingPage({
 					<div className="mt-[var(--space-block)] grid gap-[var(--space-grid)] sm:grid-cols-2">
 						{promises.map((item) => (
 							<div
-								className="border-border surface-sunken flex items-center gap-3 rounded-lg border p-4 text-sm font-bold"
+								className="surface-panel flex items-center gap-3 p-4 text-sm font-bold"
 								key={item}
 							>
 								<span className="bg-accent text-accent-foreground grid size-8 shrink-0 place-items-center rounded-md">
@@ -78,34 +77,34 @@ export function ServiceLandingPage({
 				</article>
 
 				<aside className="space-y-[var(--space-grid)] lg:sticky lg:top-[var(--header-offset)] lg:self-start">
-					<Card className="border-primary/25 bg-primary/5">
-						<CardHeader>
-							<CardTitle>Fast local response</CardTitle>
-						</CardHeader>
-						<CardContent className="text-muted-foreground space-y-4 text-sm">
-							<p className="flex gap-3">
+					<div className="surface-float rounded-xl p-[var(--space-card)]">
+						<p className="spec-label">Fast local response</p>
+						<ul className="text-on-dark-muted mt-5 space-y-0 text-sm">
+							<li className="flex gap-3 border-b border-white/10 py-3.5">
 								<Clock
-									className="text-primary size-5 shrink-0"
+									className="text-primary-bright size-5 shrink-0"
 									aria-hidden="true"
 								/>
 								{siteConfig.hours}
-							</p>
-							<p className="flex gap-3">
+							</li>
+							<li className="flex gap-3 border-b border-white/10 py-3.5">
 								<ShieldCheck
-									className="text-primary size-5 shrink-0"
+									className="text-primary-bright size-5 shrink-0"
 									aria-hidden="true"
 								/>
 								{siteConfig.licenses}
-							</p>
-							<a
-								className="text-primary flex items-center gap-3 font-bold"
-								href={siteConfig.phoneHref}
-							>
-								<Phone className="size-5 shrink-0" aria-hidden="true" />
-								{siteConfig.phone}
-							</a>
-						</CardContent>
-					</Card>
+							</li>
+							<li className="pt-3.5">
+								<a
+									className="text-primary-bright flex items-center gap-3 font-bold transition-colors hover:text-white"
+									href={siteConfig.phoneHref}
+								>
+									<Phone className="size-5 shrink-0" aria-hidden="true" />
+									{siteConfig.phone}
+								</a>
+							</li>
+						</ul>
+					</div>
 					<ContactCta compact title="Request service" />
 				</aside>
 			</section>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -36,10 +36,10 @@ export function SiteFooter() {
 			<div className="bg-primary shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.18)]">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
-						<p className="text-sm font-bold text-white/85">
+						<p className="spec-label text-white/80">
 							{siteConfig.hours}
 						</p>
-						<p className="font-display text-2xl font-extrabold tracking-[-0.03em]">
+						<p className="type-subtitle mt-1 text-white">
 							{siteConfig.phone}
 						</p>
 					</div>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -36,7 +36,7 @@ export function SiteFooter() {
 			<div className="bg-primary shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.18)]">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
 					<div>
-						<p className="spec-label text-white/80">
+						<p className="font-mono text-[0.6875rem] font-semibold tracking-[0.14em] text-white/80 uppercase">
 							{siteConfig.hours}
 						</p>
 						<p className="type-subtitle mt-1 text-white">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up design pass after the OKLCH/Phosphor redesign and cinematic home hero. Secondary surfaces now use the same hierarchy, bands, and quieter interaction language as the home page, without changing the brand look.

## What improved

- **Related content:** `surface-sunken` band, `section-head` / `spec-label`, `card-rail`, scroll reveals
- **Service areas:** map intro uses redesign section heads; county lists are hairline grids (no icon-chip cards); duplicate “Not sure?” panel folded into `ContactCta`
- **Service landing sidebar:** dark credential plate instead of copper-wash `Card`; promise tiles use `surface-panel`
- **Conversion CTA:** trust chips moved to a bottom hairline credential bar (same idea as the home hero)
- **Archives:** drop hover lift; category marks use `spec-tag`
- **Global search:** tokenized ink/`tex-glow` backdrop, `chip-rail` suggestions, typed empty state
- **404 / error:** `surface-hero` atmosphere instead of a flat void
- **Footer phone plate:** type tokens for hours/phone

## Checks

- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

