### PR TITLE
Compact mobile menu: Main, popular services, then More

### DIFF
--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ReactNode } from "react"
 import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
@@ -148,19 +149,32 @@ function MegaFooter({
 	)
 }
 
-function MobileNavLink({ href, label, description }: NavLink) {
+function MobileNavLink({
+	href,
+	label,
+	description,
+	compact = false,
+}: NavLink & { compact?: boolean }) {
 	return (
 		<SheetClose asChild>
 			<Link
-				className="hover:bg-muted focus-visible:ring-ring block rounded-md px-3 py-3 transition-colors outline-none focus-visible:ring-2"
+				className={cn(
+					"hover:bg-muted focus-visible:ring-ring block rounded-md px-3 transition-colors outline-none focus-visible:ring-2",
+					compact ? "py-2" : "py-2.5",
+				)}
 				href={href as Route}
 				prefetch
 			>
-				<span className="text-foreground block text-base font-bold tracking-[-0.02em]">
+				<span
+					className={cn(
+						"text-foreground block font-bold tracking-[-0.02em]",
+						compact ? "text-[0.9375rem]" : "text-base",
+					)}
+				>
 					{label}
 				</span>
-				{description ? (
-					<span className="text-muted-foreground mt-0.5 block text-sm">
+				{description && !compact ? (
+					<span className="text-muted-foreground mt-0.5 block text-sm leading-snug">
 						{description}
 					</span>
 				) : null}
@@ -168,6 +182,32 @@ function MobileNavLink({ href, label, description }: NavLink) {
 		</SheetClose>
 	)
 }
+
+function MobileNavSection({
+	label,
+	children,
+}: {
+	label: string
+	children: ReactNode
+}) {
+	return (
+		<section className="pt-4">
+			<p className="spec-tag px-3 pb-1.5">{label}</p>
+			{children}
+		</section>
+	)
+}
+
+const mobilePrimaryLinks: NavLink[] = [
+	{ href: "/", label: "Home" },
+	{ href: "/services", label: "Services" },
+	...midNavLinks,
+	{ href: "/contact", label: "Contact" },
+]
+
+const mobileCompanyLinks = companyNavLinks.filter(
+	(item) => item.href !== "/contact",
+)
 
 /*
  * Two columns instead of three, and no marketing tile. The old middle column of
@@ -384,51 +424,102 @@ export function SiteHeaderNav() {
 							<Menu aria-hidden="true" className="size-5" />
 						</Button>
 					</SheetTrigger>
-					<SheetContent side="right" className="bg-card">
+					<SheetContent side="right" className="bg-card gap-0">
 						<SheetHeader className="shadow-[inset_0_-1px_0_0_var(--border)]">
 							<div className="flex items-center gap-3">
 								<Image
 									alt="Wade's Plumbing & Septic logo"
-									className="size-10 rounded-md"
-									height={40}
+									className="size-9 rounded-md"
+									height={36}
 									src="/images/brand/wades-mark-sm.webp"
-									width={40}
+									width={36}
 								/>
 								<div>
-									<SheetTitle>Wade&apos;s Plumbing &amp; Septic</SheetTitle>
-									<SheetDescription>Menu · {siteConfig.hours}</SheetDescription>
+									<SheetTitle className="text-base">
+										Wade&apos;s Plumbing &amp; Septic
+									</SheetTitle>
+									<SheetDescription className="text-xs">
+										{siteConfig.hours}
+									</SheetDescription>
 								</div>
 							</div>
 						</SheetHeader>
 
+						{/*
+						  Mobile IA: primary destinations first (same order as desktop),
+						  then dense service shortcuts, then the rest of company pages.
+						  Descriptions are omitted so the sheet stays scannable.
+						*/}
 						<nav
-							className="flex-1 overflow-y-auto px-2 py-3"
+							className="flex-1 overflow-y-auto px-2 pb-4"
 							aria-label="Mobile navigation"
 						>
-							<MobileNavLink href="/" label="Home" />
+							<section className="pt-2">
+								<p className="spec-tag px-3 pb-1.5">Main</p>
+								<ul>
+									{mobilePrimaryLinks.map((item) => (
+										<li key={item.href}>
+											<MobileNavLink compact {...item} />
+										</li>
+									))}
+								</ul>
+							</section>
 
 							<Separator className="my-3" />
 
-							<p className="spec-tag px-3 pb-2">Services</p>
-							{serviceNavLinks.map((item) => (
-								<MobileNavLink key={item.href} {...item} />
-							))}
+							<MobileNavSection label="Popular services">
+								<ul>
+									{serviceMegaHighlights.map((item) => (
+										<li key={item.href}>
+											<MobileNavLink
+												compact
+												href={item.href}
+												label={item.label}
+											/>
+										</li>
+									))}
+									<li>
+										<SheetClose asChild>
+											<Link
+												className="text-primary hover:bg-muted focus-visible:ring-ring flex items-center gap-1.5 rounded-md px-3 py-2 text-[0.9375rem] font-bold outline-none focus-visible:ring-2"
+												href={"/services" as Route}
+												prefetch
+											>
+												Browse all services
+												<ArrowRight
+													aria-hidden="true"
+													className="size-3.5"
+												/>
+											</Link>
+										</SheetClose>
+									</li>
+								</ul>
+							</MobileNavSection>
 
-							<Separator className="my-3" />
+							<MobileNavSection label="Service categories">
+								<ul className="grid grid-cols-2 gap-x-1">
+									{serviceNavLinks
+										.filter((item) => item.href !== "/services")
+										.map((item) => (
+											<li key={item.href}>
+												<MobileNavLink compact href={item.href} label={item.label} />
+											</li>
+										))}
+								</ul>
+							</MobileNavSection>
 
-							{midNavLinks.map((item) => (
-								<MobileNavLink key={item.href} {...item} />
-							))}
-
-							<Separator className="my-3" />
-
-							<p className="spec-tag px-3 pb-2">Company</p>
-							{companyNavLinks.map((item) => (
-								<MobileNavLink key={item.href} {...item} />
-							))}
+							<MobileNavSection label="More">
+								<ul className="grid grid-cols-2 gap-x-1">
+									{mobileCompanyLinks.map((item) => (
+										<li key={item.href}>
+											<MobileNavLink compact href={item.href} label={item.label} />
+										</li>
+									))}
+								</ul>
+							</MobileNavSection>
 						</nav>
 
-						<SheetFooter>
+						<SheetFooter className="gap-2">
 							<a
 								className={cn(buttonVariants({ size: "lg" }), "w-full gap-2")}
 								href={siteConfig.phoneHref}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebuilds the mobile sheet so it is easier to scan: primary destinations first, then service shortcuts, then company pages in a denser grid. Long descriptions are dropped on mobile.

## New structure

1. **Main** — Home, Services, Service Area, Expert Tips, Contact  
2. **Popular services** — Engineered Septic, Septic Pumping, Hydro Jetting, plus “Browse all services”  
3. **Service categories** — 2-column compact list (Plumbing, Septic, Commercial, Urgent)  
4. **More** — About, Reviews, Careers, FAQ, Financing, Warranties (2-column)

## Why

The old menu stacked every service and company link with descriptions, so Home sat alone at the top and the rest felt like one long undifferentiated list. This mirrors desktop priority (main nav first) while keeping services discoverable without the mega-menu verbosity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

