### PR TITLE
Reduce stacked Call CTAs on content pages and mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -676,16 +676,15 @@ export default function HomePage() {
 							Straight answers to common questions.
 						</h2>
 						<p className="type-lead">
-							Do not see your question? Call and talk to someone who understands
-							the work.
+							Do not see your question? Call{" "}
+							<a
+								className="text-primary font-bold underline-offset-2 hover:underline"
+								href={siteConfig.phoneHref}
+							>
+								{siteConfig.phone}
+							</a>{" "}
+							and talk to someone who understands the work.
 						</p>
-						<a
-							className={cn(buttonVariants({ size: "lg" }), "w-full sm:w-auto")}
-							href={siteConfig.phoneHref}
-						>
-							<Phone aria-hidden="true" />
-							{siteConfig.phone}
-						</a>
 					</div>
 					<HomeFaq faqs={faqs} />
 				</div>

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -9,10 +9,13 @@ export function ContactCta({
 	title = "Ready to get started?",
 	description = "Talk to a local licensed professional and get clear options with no pressure.",
 	compact = false,
+	/** Big Call button. Off by default in compact sidebars so pages do not stack Call on Call. */
+	showCall,
 }: {
 	title?: string
 	description?: string
 	compact?: boolean
+	showCall?: boolean
 }) {
 	/*
 	 * Two shapes, one component. The banner is a grid rather than a
@@ -20,7 +23,12 @@ export function ContactCta({
 	 * shrinkage against the shrink-0 button group and collapsed to its longest
 	 * word. The compact shape stays stacked at every width - it lives in a
 	 * 20.5rem sidebar, where side-by-side xl buttons overflowed the card.
+	 *
+	 * Compact sidebars omit the Call button by default: content/service pages
+	 * already offer Call in the hero and again in the end conversion band, and
+	 * on mobile the sidebar stacks right above that band.
 	 */
+	const includeCall = showCall ?? !compact
 	const actionWidth = compact ? "w-full" : "w-full sm:w-auto"
 
 	return (
@@ -49,7 +57,15 @@ export function ContactCta({
 					>
 						{description}
 					</p>
-					{!compact ? (
+					{compact ? (
+						<a
+							className="text-primary-bright inline-flex items-center gap-2 text-sm font-bold transition-colors hover:text-white"
+							href={siteConfig.phoneHref}
+						>
+							<Phone className="size-4 shrink-0" aria-hidden="true" />
+							{siteConfig.phone}
+						</a>
+					) : (
 						<div className="text-on-dark-muted flex flex-wrap gap-x-6 gap-y-2 text-sm">
 							<span className="inline-flex items-center gap-2">
 								<Clock className="text-primary-bright size-4 shrink-0" />
@@ -63,29 +79,31 @@ export function ContactCta({
 								{siteConfig.email}
 							</a>
 						</div>
-					) : null}
+					)}
 				</div>
 
 				<div
 					className={cn(
 						"flex flex-col items-stretch gap-3",
-						compact ? "mt-6" : "sm:flex-row sm:items-center md:shrink-0",
+						compact ? "mt-5" : "sm:flex-row sm:items-center md:shrink-0",
 					)}
 				>
-					<a
-						className={cn(
-							buttonVariants({ size: compact ? "lg" : "xl" }),
-							actionWidth,
-						)}
-						href={siteConfig.phoneHref}
-					>
-						<Phone aria-hidden="true" />
-						Call {siteConfig.phone}
-					</a>
+					{includeCall ? (
+						<a
+							className={cn(
+								buttonVariants({ size: compact ? "lg" : "xl" }),
+								actionWidth,
+							)}
+							href={siteConfig.phoneHref}
+						>
+							<Phone aria-hidden="true" />
+							Call {siteConfig.phone}
+						</a>
+					) : null}
 					<Link
 						className={cn(
 							buttonVariants({
-								variant: "inverse",
+								variant: includeCall ? "inverse" : "default",
 								size: compact ? "lg" : "xl",
 							}),
 							actionWidth,
@@ -93,7 +111,7 @@ export function ContactCta({
 						href="/contact"
 						prefetch
 					>
-						Send a Message
+						{compact ? "Request service" : "Send a Message"}
 						<ArrowRight aria-hidden="true" />
 					</Link>
 				</div>

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -149,9 +149,16 @@ export function ContentHero({
 					</p>
 				</div>
 
+				{/*
+				  Mobile header already exposes a phone icon, so the hero leads with
+				  Quote there and keeps the big Call button from sm up.
+				*/}
 				<div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
 					<a
-						className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
+						className={cn(
+							buttonVariants({ size: "xl" }),
+							"hidden w-full sm:inline-flex sm:w-auto",
+						)}
 						href={siteConfig.phoneHref}
 					>
 						<Phone aria-hidden="true" />
@@ -159,14 +166,31 @@ export function ContentHero({
 					</a>
 					<Link
 						className={cn(
-							buttonVariants({ variant: "inverse", size: "xl" }),
-							"w-full sm:w-auto",
+							buttonVariants({ size: "xl" }),
+							"w-full sm:hidden",
 						)}
 						href="/contact"
 						prefetch
 					>
 						Get a Free Quote
 					</Link>
+					<Link
+						className={cn(
+							buttonVariants({ variant: "inverse", size: "xl" }),
+							"hidden w-full sm:inline-flex sm:w-auto",
+						)}
+						href="/contact"
+						prefetch
+					>
+						Get a Free Quote
+					</Link>
+					<a
+						className="text-on-dark-muted hover:text-primary-bright inline-flex items-center justify-center gap-2 text-sm font-bold transition-colors sm:hidden"
+						href={siteConfig.phoneHref}
+					>
+						<Phone className="size-4" aria-hidden="true" />
+						Or call {siteConfig.phone}
+					</a>
 				</div>
 			</div>
 		</section>

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -71,7 +71,11 @@ export function ContentPage({
 					) : null}
 					<MarkdownContent content={document.content} />
 				</div>
-				<aside className="lg:sticky lg:top-[var(--header-offset)] lg:self-start">
+				{/*
+				  Desktop-only sidebar. On mobile this sat between the article and the
+				  end conversion CTA, so Call / Request / Call stacked back to back.
+				*/}
+				<aside className="hidden lg:sticky lg:top-[var(--header-offset)] lg:block lg:self-start">
 					<ContactCta
 						compact
 						description="Tell us what is happening and get practical options from a local licensed team."

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -76,7 +76,12 @@ export function ServiceLandingPage({
 					</div>
 				</article>
 
-				<aside className="space-y-[var(--space-grid)] lg:sticky lg:top-[var(--header-offset)] lg:self-start">
+				{/*
+				  Desktop sticky rail only. Mobile already has the hero CTAs plus the
+				  end conversion band; stacking another Call/Request block here felt
+				  spammy on short viewports.
+				*/}
+				<aside className="hidden space-y-[var(--space-grid)] lg:sticky lg:top-[var(--header-offset)] lg:block lg:self-start">
 					<div className="surface-float rounded-xl p-[var(--space-card)]">
 						<p className="spec-label">Fast local response</p>
 						<ul className="text-on-dark-muted mt-5 space-y-0 text-sm">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Content and service pages stacked the same Call button too many times, especially on mobile:

1. Header phone icon  
2. Hero **Call**  
3. Sidebar **Call** (after the article)  
4. End conversion **Call**

That felt spammy when the sidebar and bottom CTA sat back to back.

## Changes

- **Mobile sidebars hidden** on content + service pages (desktop sticky rail stays)
- **Compact `ContactCta`** is message-first: phone as a text link, no big Call button
- **Content hero on mobile:** primary **Get a Free Quote**, with “Or call …” as text (header already has the phone icon)
- **Home FAQ:** removed the extra Call button that sat directly above `ContactCta`

## What stays

- Sticky header phone (mobile) / Call button (desktop)
- End-of-page conversion Call CTA
- Footer Call now
- Desktop hero Call + Quote

## Checks

- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

