### PR TITLE
Harden Cache Components and React performance paths

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,9 +1,14 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
 import { ContentPage } from "@/components/content-page"
-import { getCollection, getDocument, getPageOrPost } from "@/lib/content"
+import {
+	getCollection,
+	resolvePageOrPost,
+	type ContentDocument,
+} from "@/lib/content"
 import { getRelatedForPost, getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -25,19 +30,17 @@ export async function generateMetadata({
 }): Promise<Metadata> {
 	const { slug: slugParts } = await params
 	const slug = slugParts.join("/")
-	const document = await getPageOrPost(slug)
+	const resolved = await resolvePageOrPost(slug)
 
-	if (!document) return {}
-
-	const isPost = Boolean(await getDocument("posts", slug))
+	if (!resolved) return {}
 
 	return buildPageMetadata({
-		title: document.title,
-		description: document.description,
-		pathname: `/${document.slug}`,
-		image: document.image,
-		type: isPost ? "article" : "website",
-		noindex: document.noindex,
+		title: resolved.document.title,
+		description: resolved.document.description,
+		pathname: `/${resolved.document.slug}`,
+		image: resolved.document.image,
+		type: resolved.isPost ? "article" : "website",
+		noindex: resolved.document.noindex,
 	})
 }
 
@@ -45,9 +48,16 @@ async function RelatedMarkdownPage({
 	document,
 	isPost,
 }: {
-	document: NonNullable<Awaited<ReturnType<typeof getPageOrPost>>>
+	document: ContentDocument
 	isPost: boolean
 }) {
+	"use cache"
+	cacheTag(
+		`content:${isPost ? "posts" : "pages"}`,
+		`content:${isPost ? "posts" : "pages"}:${document.slug}`,
+	)
+	cacheLife("max")
+
 	const related = isPost
 		? await getRelatedForPost(document)
 		: document.slug.startsWith("service-area/")
@@ -77,16 +87,16 @@ export default async function MarkdownPage({
 }) {
 	const { slug: slugParts } = await params
 	const slug = slugParts.join("/")
-	const [document, post] = await Promise.all([
-		getPageOrPost(slug),
-		getDocument("posts", slug),
-	])
+	const resolved = await resolvePageOrPost(slug)
 
-	if (!document) notFound()
+	if (!resolved) notFound()
 
 	return (
 		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<RelatedMarkdownPage document={document} isPost={Boolean(post)} />
+			<RelatedMarkdownPage
+				document={resolved.document}
+				isPost={resolved.isPost}
+			/>
 		</Suspense>
 	)
 }

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
+import { Suspense } from "react"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
@@ -59,15 +61,13 @@ export async function generateMetadata({
 	})
 }
 
-export default async function CategoryPage({
-	params,
-}: {
-	params: Promise<{ slug: string }>
-}) {
-	const { slug } = await params
-	const posts = await postsForCategory(slug)
+async function CategoryArchive({ slug }: { slug: string }) {
+	"use cache"
+	cacheTag("content:posts", `content:category:${slug}`)
+	cacheLife("max")
 
-	if (!posts.length) notFound()
+	const posts = await postsForCategory(slug)
+	if (!posts.length) return null
 
 	const label = aliases[slug]?.[0] ?? posts[0]?.category ?? "Expert Tips"
 	const related = await getRelatedForTopic(
@@ -88,5 +88,22 @@ export default async function CategoryPage({
 			related={related}
 			title={label}
 		/>
+	)
+}
+
+export default async function CategoryPage({
+	params,
+}: {
+	params: Promise<{ slug: string }>
+}) {
+	const { slug } = await params
+	const posts = await postsForCategory(slug)
+
+	if (!posts.length) notFound()
+
+	return (
+		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
+			<CategoryArchive slug={slug} />
+		</Suspense>
 	)
 }

--- a/app/expert-tips/page.tsx
+++ b/app/expert-tips/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
@@ -18,6 +19,8 @@ export const metadata: Metadata = buildPageMetadata({
 
 async function TipsGrid() {
 	"use cache"
+	cacheTag("content:posts")
+	cacheLife("max")
 
 	const posts = await getCollection("posts")
 	const items = posts.map((post) =>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata, Viewport } from "next"
-import { Analytics } from "@vercel/analytics/next"
 import { Archivo, Manrope } from "next/font/google"
+import { cacheLife, cacheTag } from "next/cache"
 import { Suspense } from "react"
 
+import { AnalyticsLoader } from "@/components/analytics-loader"
 import { CommandMenuLoader } from "@/components/command-menu-loader"
 import { JsonLd } from "@/components/json-ld"
 import { SiteFooter } from "@/components/site-footer"
@@ -98,9 +99,11 @@ export const viewport: Viewport = {
 	],
 }
 
-export default async function RootLayout({
-	children,
-}: Readonly<{ children: React.ReactNode }>) {
+async function RootJsonLd() {
+	"use cache"
+	cacheTag("content:services")
+	cacheLife("max")
+
 	const services = await getCollection("services")
 	const organizationSchema = localBusinessJsonLd(
 		services.map((service) => ({
@@ -110,6 +113,12 @@ export default async function RootLayout({
 		})),
 	)
 
+	return <JsonLd data={[websiteJsonLd(), organizationSchema]} />
+}
+
+export default function RootLayout({
+	children,
+}: Readonly<{ children: React.ReactNode }>) {
 	return (
 		<html
 			lang="en"
@@ -137,8 +146,10 @@ export default async function RootLayout({
 					</Suspense>
 					<SiteFooter />
 					<CommandMenuLoader />
-					<JsonLd data={[websiteJsonLd(), organizationSchema]} />
-					<Analytics />
+					<Suspense fallback={null}>
+						<RootJsonLd />
+					</Suspense>
+					<AnalyticsLoader />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/app/service-areas/page.tsx
+++ b/app/service-areas/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
-import { ServiceAreasMap } from "@/components/service-areas-map"
+import { ServiceAreasMapLazy } from "@/components/service-areas-map-lazy"
 import type { ContentDocument } from "@/lib/content"
 import { normalizeConversion } from "@/lib/content-conversion"
 import { locationsByCounty, serviceAreaLocations } from "@/lib/service-areas"
@@ -79,9 +79,9 @@ export default function ServiceAreasPage() {
 					</div>
 				</div>
 
-				{/* Full-bleed on mobile; map component constrains itself from md up. */}
+				{/* Full-bleed on mobile; map chunk loads after the static shell. */}
 				<div className="mt-[var(--space-block)]">
-					<ServiceAreasMap />
+					<ServiceAreasMapLazy />
 				</div>
 
 				<p className="text-muted-foreground container-shell mt-4 text-center text-sm font-bold">

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
@@ -70,6 +71,8 @@ const categories = {
 	},
 } as const
 
+type CategorySlug = keyof typeof categories
+
 export function generateStaticParams() {
 	return Object.keys(categories).map((slug) => ({ slug }))
 }
@@ -80,7 +83,7 @@ export async function generateMetadata({
 	params: Promise<{ slug: string }>
 }): Promise<Metadata> {
 	const { slug } = await params
-	const category = categories[slug as keyof typeof categories]
+	const category = categories[slug as CategorySlug]
 
 	if (!category) return {}
 
@@ -92,16 +95,12 @@ export async function generateMetadata({
 	})
 }
 
-export default async function ServiceCategoryPage({
-	params,
-}: {
-	params: Promise<{ slug: string }>
-}) {
-	const { slug } = await params
-	const category = categories[slug as keyof typeof categories]
+async function ServiceCategoryBody({ slug }: { slug: CategorySlug }) {
+	"use cache"
+	cacheTag("content:services", `content:service-category:${slug}`)
+	cacheLife("max")
 
-	if (!category) notFound()
-
+	const category = categories[slug]
 	const services = (await getCollection("services")).filter(
 		(service) => service.category === category.contentCategory,
 	)
@@ -160,5 +159,22 @@ export default async function ServiceCategoryPage({
 			/>
 			<ContactCta />
 		</main>
+	)
+}
+
+export default async function ServiceCategoryPage({
+	params,
+}: {
+	params: Promise<{ slug: string }>
+}) {
+	const { slug } = await params
+	const category = categories[slug as CategorySlug]
+
+	if (!category) notFound()
+
+	return (
+		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
+			<ServiceCategoryBody slug={slug as CategorySlug} />
+		</Suspense>
 	)
 }

--- a/app/service-offerings/[slug]/page.tsx
+++ b/app/service-offerings/[slug]/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
 import { Suspense } from "react"
 
 import { ServiceLandingPage } from "@/components/service-landing-page"
-import { getCollection, getDocument } from "@/lib/content"
+import { getCollection, getDocument, type ContentDocument } from "@/lib/content"
 import { getRelatedForService } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
 import { buildPageMetadata } from "@/lib/seo"
@@ -31,11 +32,11 @@ export async function generateMetadata({
 	})
 }
 
-async function RelatedServicePage({
-	service,
-}: {
-	service: NonNullable<Awaited<ReturnType<typeof getDocument>>>
-}) {
+async function RelatedServicePage({ service }: { service: ContentDocument }) {
+	"use cache"
+	cacheTag("content:services", `content:services:${service.slug}`)
+	cacheLife("max")
+
 	const related = await getRelatedForService(service)
 	return <ServiceLandingPage related={related} service={service} />
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
@@ -18,6 +19,8 @@ export const metadata: Metadata = buildPageMetadata({
 
 async function ServiceDirectory() {
 	"use cache"
+	cacheTag("content:services")
+	cacheLife("max")
 
 	const services = await getCollection("services")
 	const items = services.map((service) =>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 
 import { getAllRoutes, taxonomySlug } from "@/lib/content"
 import { siteConfig } from "@/lib/site"
@@ -22,6 +23,8 @@ function entry(
 
 async function buildSitemapEntries(): Promise<SitemapEntry[]> {
 	"use cache"
+	cacheTag("content:routes", "content:pages", "content:services", "content:posts")
+	cacheLife("max")
 
 	const { pages, services, posts } = await getAllRoutes()
 

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next"
+import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
+import { Suspense } from "react"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
@@ -13,22 +15,34 @@ export async function generateStaticParams() {
 	return [...new Set(slugs)].map((slug) => ({ slug }))
 }
 
+async function postsForTag(slug: string) {
+	const posts = await getCollection("posts")
+	return posts.filter((post) =>
+		post.tags?.some((tag) => taxonomySlug(tag) === slug),
+	)
+}
+
+function labelForTag(
+	slug: string,
+	matched: Awaited<ReturnType<typeof postsForTag>>,
+) {
+	return (
+		matched[0]?.tags?.find((tag) => taxonomySlug(tag) === slug) ??
+		slug.replaceAll("-", " ")
+	)
+}
+
 export async function generateMetadata({
 	params,
 }: {
 	params: Promise<{ slug: string }>
 }): Promise<Metadata> {
 	const { slug } = await params
-	const posts = await getCollection("posts")
-	const matched = posts.filter((post) =>
-		post.tags?.some((tag) => taxonomySlug(tag) === slug),
-	)
+	const matched = await postsForTag(slug)
 
 	if (!matched.length) return {}
 
-	const label =
-		matched[0]?.tags?.find((tag) => taxonomySlug(tag) === slug) ??
-		slug.replaceAll("-", " ")
+	const label = labelForTag(slug, matched)
 
 	return buildPageMetadata({
 		title: `${label} Guides`,
@@ -37,23 +51,15 @@ export async function generateMetadata({
 	})
 }
 
-export default async function TagPage({
-	params,
-}: {
-	params: Promise<{ slug: string }>
-}) {
-	const { slug } = await params
-	const posts = await getCollection("posts")
-	const matched = posts.filter((post) =>
-		post.tags?.some((tag) => taxonomySlug(tag) === slug),
-	)
+async function TagArchive({ slug }: { slug: string }) {
+	"use cache"
+	cacheTag("content:posts", `content:tag:${slug}`)
+	cacheLife("max")
 
-	if (!matched.length) notFound()
+	const matched = await postsForTag(slug)
+	if (!matched.length) return null
 
-	const label =
-		matched[0]?.tags?.find((tag) => taxonomySlug(tag) === slug) ??
-		slug.replaceAll("-", " ")
-
+	const label = labelForTag(slug, matched)
 	const related = await getRelatedForTopic(
 		{
 			label,
@@ -72,5 +78,22 @@ export default async function TagPage({
 			related={related}
 			title={label}
 		/>
+	)
+}
+
+export default async function TagPage({
+	params,
+}: {
+	params: Promise<{ slug: string }>
+}) {
+	const { slug } = await params
+	const matched = await postsForTag(slug)
+
+	if (!matched.length) notFound()
+
+	return (
+		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
+			<TagArchive slug={slug} />
+		</Suspense>
 	)
 }

--- a/components/analytics-loader.tsx
+++ b/components/analytics-loader.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import { useEffect, useState } from "react"
+
+const Analytics = dynamic(
+	() => import("@vercel/analytics/next").then((mod) => mod.Analytics),
+	{ ssr: false },
+)
+
+/**
+ * Defers Vercel Analytics until the browser is idle so it does not compete
+ * with LCP / hydration on marketing pages.
+ */
+export function AnalyticsLoader() {
+	const [ready, setReady] = useState(false)
+
+	useEffect(() => {
+		const idleWindow = window as Window & {
+			requestIdleCallback?: (
+				callback: IdleRequestCallback,
+				options?: IdleRequestOptions,
+			) => number
+			cancelIdleCallback?: (handle: number) => void
+		}
+
+		if (idleWindow.requestIdleCallback) {
+			const id = idleWindow.requestIdleCallback(
+				() => setReady(true),
+				{ timeout: 2500 },
+			)
+			return () => idleWindow.cancelIdleCallback?.(id)
+		}
+
+		const timer = globalThis.setTimeout(() => setReady(true), 400)
+		return () => globalThis.clearTimeout(timer)
+	}, [])
+
+	if (!ready) return null
+	return <Analytics />
+}

--- a/components/service-areas-map-lazy.tsx
+++ b/components/service-areas-map-lazy.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const ServiceAreasMap = dynamic(
+	() =>
+		import("@/components/service-areas-map").then(
+			(mod) => mod.ServiceAreasMap,
+		),
+	{
+		ssr: false,
+		loading: () => (
+			<div
+				aria-hidden
+				className="bg-muted mx-auto min-h-[min(70vh,36rem)] w-full max-w-6xl animate-pulse rounded-lg md:min-h-[28rem]"
+			/>
+		),
+	},
+)
+
+/** Lazy MapLibre entry so the service-areas shell can paint without the map chunk. */
+export function ServiceAreasMapLazy() {
+	return <ServiceAreasMap />
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -162,9 +162,23 @@ export async function getDocument(collection: Collection, slug: string) {
 }
 
 export async function getPageOrPost(slug: string) {
-	return (
-		(await getDocument("pages", slug)) ?? (await getDocument("posts", slug))
-	)
+	const [page, post] = await Promise.all([
+		getDocument("pages", slug),
+		getDocument("posts", slug),
+	])
+	return page ?? post
+}
+
+/** Resolve a page or post once, including which collection matched. */
+export async function resolvePageOrPost(slug: string) {
+	const [page, post] = await Promise.all([
+		getDocument("pages", slug),
+		getDocument("posts", slug),
+	])
+
+	if (page) return { document: page, isPost: false as const }
+	if (post) return { document: post, isPost: true as const }
+	return undefined
 }
 
 export function taxonomySlug(value: string) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Applies Next.js Cache Components and Vercel React best-practice patterns on top of the already-enabled `cacheComponents` setup.

## Changes
- **Parallel content resolution** (`lib/content.ts`): `getPageOrPost` / new `resolvePageOrPost` use `Promise.all` so posts no longer wait on a failed pages lookup; markdown metadata stops double-fetching.
- **Durable `use cache` boundaries** with `cacheLife("max")` + `cacheTag(...)` on related markdown pages, service offerings, services/expert-tips grids, category/tag/service-category archives, and the sitemap builder.
- **Non-blocking root layout**: move LocalBusiness JSON-LD into a cached `RootJsonLd` behind `Suspense` so header/footer are not blocked on services collection I/O.
- **Defer third-party / heavy clients**:
  - `AnalyticsLoader` loads Vercel Analytics after idle
  - `ServiceAreasMapLazy` code-splits MapLibre off the service-areas shell

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run build` (Cache Components enabled; routes show ○ static / ◐ PPR as expected)

## Notes
Header mega-menu still ships in the shared client shell; further splitting that is a follow-up if we want more layout JS reduction.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

