### PR TITLE
Remove right sidebars from content pages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -174,16 +174,13 @@
 
 	--content-max: 78rem;
 	/*
-	  Article templates run narrower than marketing sections. At the full
-	  78rem the body column measured 876px while the prose capped at its 68ch
-	  measure, leaving a ~170px void between the copy and the sidebar. 67rem
-	  lands the column on the measure so the two columns actually meet.
+	  Single-column article templates. Sized to the prose measure plus a little
+	  room for galleries and two-up promise cards on service pages.
 	*/
-	--content-max-article: 62rem;
+	--content-max-article: 48rem;
 	/* ch measures the "0" glyph, which is wider than average lowercase, so
 	   60ch lands around 75 real characters a line. */
 	--measure: 60ch;
-	--sidebar-w: 20.5rem;
 	--header-offset: 6.5rem;
 	/* Visible header height, used to size the cinematic hero to the viewport.
 	   Matches the 64px bar on phones; the utility bar adds 28px from sm up. */
@@ -390,7 +387,7 @@
 		margin-inline: auto;
 	}
 
-	/* Body-copy + sidebar templates. */
+	/* Single-column body-copy templates. */
 	.article-shell {
 		width: min(100% - (var(--space-page-x) * 2), var(--content-max-article));
 		margin-inline: auto;

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/lib/seo"
 import { siteConfig } from "@/lib/site"
 
-import { ContactCta } from "@/components/contact-cta"
 import { ContentConversionCta } from "@/components/content-conversion-cta"
 import { ContentGallery } from "@/components/content-gallery"
 import { ContentHero } from "@/components/content-hero"
@@ -73,40 +72,25 @@ export function ContentPage({
 				parent={parent}
 				title={document.title}
 			/>
-			{/* Sidebar width comes from --sidebar-w so this template and the service
-			    template share one measurement (they were 20rem and 21rem). */}
-			<article className="article-shell section-y grid items-start gap-[var(--space-block)] lg:grid-cols-[minmax(0,1fr)_var(--sidebar-w)]">
-				<div className="min-w-0">
-					{isPost && document.date ? (
-						<p className="type-meta border-border mb-8 border-b pb-5 font-bold">
-							Published{" "}
-							<time dateTime={document.date}>
-								{new Intl.DateTimeFormat("en-US", {
-									year: "numeric",
-									month: "long",
-									day: "numeric",
-									timeZone: "UTC",
-								}).format(new Date(`${document.date}T00:00:00Z`))}
-							</time>
-							{document.updated ? ` · Updated ${document.updated}` : null}
-						</p>
-					) : null}
-					{document.gallery?.length ? (
-						<ContentGallery images={document.gallery} />
-					) : null}
-					<MarkdownContent content={document.content} demoteH1 />
-				</div>
-				{/*
-				  Desktop-only sidebar. On mobile this sat between the article and the
-				  end conversion CTA, so Call / Request / Call stacked back to back.
-				*/}
-				<aside className="hidden lg:sticky lg:top-[var(--header-offset)] lg:block lg:self-start">
-					<ContactCta
-						compact
-						description="Tell us what is happening and get practical options from a local licensed team."
-						title="Need help with this?"
-					/>
-				</aside>
+			<article className="article-shell section-y">
+				{isPost && document.date ? (
+					<p className="type-meta border-border mb-8 border-b pb-5 font-bold">
+						Published{" "}
+						<time dateTime={document.date}>
+							{new Intl.DateTimeFormat("en-US", {
+								year: "numeric",
+								month: "long",
+								day: "numeric",
+								timeZone: "UTC",
+							}).format(new Date(`${document.date}T00:00:00Z`))}
+						</time>
+						{document.updated ? ` · Updated ${document.updated}` : null}
+					</p>
+				) : null}
+				{document.gallery?.length ? (
+					<ContentGallery images={document.gallery} />
+				) : null}
+				<MarkdownContent content={document.content} demoteH1 />
 			</article>
 			{related ? <RelatedContentSections related={related} /> : null}
 			<ContentConversionCta

--- a/components/service-landing-page.tsx
+++ b/components/service-landing-page.tsx
@@ -1,6 +1,5 @@
-import { Check, Clock, Phone, ShieldCheck } from "@/components/icons"
+import { Check } from "@/components/icons"
 
-import { ContactCta } from "@/components/contact-cta"
 import { ContentConversionCta } from "@/components/content-conversion-cta"
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
@@ -65,8 +64,8 @@ export function ServiceLandingPage({
 				title={service.title}
 			/>
 
-			<section className="article-shell section-y grid items-start gap-[var(--space-block)] lg:grid-cols-[minmax(0,1fr)_var(--sidebar-w)]">
-				<article className="min-w-0">
+			<section className="article-shell section-y">
+				<article>
 					<MarkdownContent content={service.content} demoteH1 />
 
 					<div className="mt-[var(--space-block)] grid gap-[var(--space-grid)] sm:grid-cols-2">
@@ -83,43 +82,6 @@ export function ServiceLandingPage({
 						))}
 					</div>
 				</article>
-
-				{/*
-				  Desktop sticky rail only. Mobile already has the hero CTAs plus the
-				  end conversion band; stacking another Call/Request block here felt
-				  spammy on short viewports.
-				*/}
-				<aside className="hidden space-y-[var(--space-grid)] lg:sticky lg:top-[var(--header-offset)] lg:block lg:self-start">
-					<div className="surface-float rounded-xl p-[var(--space-card)]">
-						<p className="spec-label">Fast local response</p>
-						<ul className="text-on-dark-muted mt-5 space-y-0 text-sm">
-							<li className="flex gap-3 border-b border-white/10 py-3.5">
-								<Clock
-									className="text-primary-bright size-5 shrink-0"
-									aria-hidden="true"
-								/>
-								{siteConfig.hours}
-							</li>
-							<li className="flex gap-3 border-b border-white/10 py-3.5">
-								<ShieldCheck
-									className="text-primary-bright size-5 shrink-0"
-									aria-hidden="true"
-								/>
-								{siteConfig.licenses}
-							</li>
-							<li className="pt-3.5">
-								<a
-									className="text-primary-bright flex items-center gap-3 font-bold transition-colors hover:text-white"
-									href={siteConfig.phoneHref}
-								>
-									<Phone className="size-5 shrink-0" aria-hidden="true" />
-									{siteConfig.phone}
-								</a>
-							</li>
-						</ul>
-					</div>
-					<ContactCta compact title="Request service" />
-				</aside>
 			</section>
 
 			{related ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Removes the sticky right-hand contact sidebar from content templates so articles and service pages read as a single column.

## Changes
- `components/content-page.tsx`: drop sidebar CTA rail
- `components/service-landing-page.tsx`: drop hours/license/contact rail
- `app/globals.css`: remove `--sidebar-w`, tighten `--content-max-article` to the single-column measure

End-of-page conversion CTAs and archive/page-level Contact CTAs remain.

## Verification
- `npm run typecheck`
- `npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

