### PR TITLE
Fix layout conflict markers from #62 merge

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -128,15 +128,10 @@ export default function RootLayout({
 	children,
 }: Readonly<{ children: React.ReactNode }>) {
 	return (
-<<<<<<< HEAD
 		<html
 			lang="en"
 			className={`${manrope.variable} ${archivo.variable} ${geist.variable} ${geistMono.variable}`}
-			suppressHydrationWarning
 		>
-=======
-		<html lang="en" className={`${manrope.variable} ${archivo.variable}`}>
->>>>>>> origin/main
 			<body className={manrope.className}>
 				<a
 					className="sr-only z-[100] rounded-br-lg bg-white p-3 text-black focus:not-sr-only focus:fixed focus:top-0 focus:left-0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes unresolved merge conflict markers that landed on `main` via PR #62.
- Keeps Manrope, Archivo, and Geist font variables for typeset content surfaces.

## Test plan
- [x] Confirm `app/layout.tsx` has no conflict markers
- [ ] Preview deploy builds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

