### PR TITLE
Fix layout conflict markers from #63 merge

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -131,10 +131,6 @@ export default function RootLayout({
 		<html
 			lang="en"
 			className={`${manrope.variable} ${archivo.variable} ${geist.variable} ${geistMono.variable}`}
-<<<<<<< HEAD
-			suppressHydrationWarning
-=======
->>>>>>> origin/main
 		>
 			<body className={manrope.className}>
 				<a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removes unresolved merge conflict markers that landed on `main` via PR #63.
- Layout keeps Manrope, Archivo, and Geist font variables.

## Test plan
- [x] `app/layout.tsx` has no conflict markers
- [ ] Preview deploy builds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-612a1dc2-7664-4f96-81b3-973fcad0a164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

