### PR TITLE
Fix mobile links dying from truncated RSC page shells

### DIFF
--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
-import { connection } from "next/server"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 
 import { ContentPage } from "@/components/content-page"
 import {
@@ -10,11 +8,7 @@ import {
 	resolvePageOrPost,
 	type ContentDocument,
 } from "@/lib/content"
-import {
-	getPageViewStoreCached,
-	getStatsForSlug,
-} from "@/lib/page-views"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { getLiveViewStats } from "@/lib/page-views/live"
 import { getRelatedForPost, getRelatedForTopic } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 
@@ -81,32 +75,6 @@ async function getRelatedForDocument(
 	return undefined
 }
 
-async function RelatedMarkdownPage({
-	document,
-	isPost,
-}: {
-	document: ContentDocument
-	isPost: boolean
-}) {
-	const related = await getRelatedForDocument(document, isPost)
-
-	await connection()
-	const today = utcDayNow()
-	const store = await getPageViewStoreCached()
-	const viewStats = isPost
-		? getStatsForSlug(store, "tip", document.slug, today)
-		: undefined
-
-	return (
-		<ContentPage
-			document={document}
-			isPost={isPost}
-			related={related}
-			viewStats={viewStats}
-		/>
-	)
-}
-
 export default async function MarkdownPage({
 	params,
 }: {
@@ -118,12 +86,20 @@ export default async function MarkdownPage({
 
 	if (!resolved) notFound()
 
+	const related = await getRelatedForDocument(
+		resolved.document,
+		resolved.isPost,
+	)
+	const viewStats = resolved.isPost
+		? await getLiveViewStats("tip", resolved.document.slug)
+		: undefined
+
 	return (
-		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<RelatedMarkdownPage
-				document={resolved.document}
-				isPost={resolved.isPost}
-			/>
-		</Suspense>
+		<ContentPage
+			document={resolved.document}
+			isPost={resolved.isPost}
+			related={related}
+			viewStats={viewStats}
+		/>
 	)
 }

--- a/app/api/search-index/route.ts
+++ b/app/api/search-index/route.ts
@@ -1,19 +1,11 @@
-import { useLogger, withEvlog } from "@/lib/evlog"
 import { getSearchIndex } from "@/lib/search-index"
 
-export const GET = withEvlog(async () => {
-	const log = useLogger()
+export async function GET() {
 	const index = await getSearchIndex()
-
-	log.set({
-		searchIndex: {
-			documentCount: index.length,
-		},
-	})
 
 	return Response.json(index, {
 		headers: {
 			"Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
 		},
 	})
-})
+}

--- a/app/category/[slug]/page.tsx
+++ b/app/category/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
@@ -100,9 +99,5 @@ export default async function CategoryPage({
 
 	if (!posts.length) notFound()
 
-	return (
-		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<CategoryArchive slug={slug} />
-		</Suspense>
-	)
+	return <CategoryArchive slug={slug} />
 }

--- a/app/expert-tips/page.tsx
+++ b/app/expert-tips/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -48,21 +47,13 @@ export default function ExpertTipsPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<section className="container-shell section-y">
-						Loading guides…
-					</section>
-				}
-			>
-				<RankedContentArchive
-					allLabel="All guides"
-					emptyLabel="No guides in this category."
-					noun={{ singular: "guide", plural: "guides" }}
-					pageSize={9}
-					variant="tip"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="All guides"
+				emptyLabel="No guides in this category."
+				noun={{ singular: "guide", plural: "guides" }}
+				pageSize={9}
+				variant="tip"
+			/>
 
 			<ContactCta title="Have a plumbing or septic question?" />
 		</main>

--- a/app/expert-tips/popular/page.tsx
+++ b/app/expert-tips/popular/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -56,23 +55,15 @@ export default function PopularTipsPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<section className="container-shell section-y">
-						Loading guides…
-					</section>
-				}
-			>
-				<RankedContentArchive
-					allLabel="Most popular guides"
-					emptyLabel="No guides in this category."
-					lockedSort
-					noun={{ singular: "guide", plural: "guides" }}
-					pageSize={9}
-					sort="popular"
-					variant="tip"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="Most popular guides"
+				emptyLabel="No guides in this category."
+				lockedSort
+				noun={{ singular: "guide", plural: "guides" }}
+				pageSize={9}
+				sort="popular"
+				variant="tip"
+			/>
 
 			<ContactCta title="Have a plumbing or septic question?" />
 		</main>

--- a/app/expert-tips/trending/page.tsx
+++ b/app/expert-tips/trending/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -57,23 +56,15 @@ export default function TrendingTipsPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<section className="container-shell section-y">
-						Loading guides…
-					</section>
-				}
-			>
-				<RankedContentArchive
-					allLabel="Trending guides"
-					emptyLabel="No guides in this category."
-					lockedSort
-					noun={{ singular: "guide", plural: "guides" }}
-					pageSize={9}
-					sort="trending"
-					variant="tip"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="Trending guides"
+				emptyLabel="No guides in this category."
+				lockedSort
+				noun={{ singular: "guide", plural: "guides" }}
+				pageSize={9}
+				sort="trending"
+				variant="tip"
+			/>
 
 			<ContactCta title="Have a plumbing or septic question?" />
 		</main>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -140,11 +140,7 @@ export default function RootLayout({
 					Skip to content
 				</a>
 				<SiteHeader />
-				<Suspense
-					fallback={<main id="main-content" className="min-h-[40vh]" />}
-				>
-					{children}
-				</Suspense>
+				{children}
 				<SiteFooter />
 				<CommandMenuLoader />
 				<Suspense fallback={null}>

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,22 +1,12 @@
 import { getAllRoutes } from "@/lib/content"
-import { useLogger, withEvlog } from "@/lib/evlog"
 import { siteConfig } from "@/lib/site"
 
-export const GET = withEvlog(async () => {
-	const log = useLogger()
+export async function GET() {
 	const { services, posts, pages } = await getAllRoutes()
 
 	const serviceAreas = pages.filter((page) =>
 		page.slug.startsWith("service-area/"),
 	)
-
-	log.set({
-		llmsTxt: {
-			serviceCount: services.length,
-			tipCount: Math.min(posts.length, 40),
-			serviceAreaCount: serviceAreas.length,
-		},
-	})
 
 	const serviceLines = services
 		.map(
@@ -83,4 +73,4 @@ ${areaLines}
 			"Cache-Control": "public, max-age=3600, s-maxage=86400",
 		},
 	})
-})
+}

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
-import { connection } from "next/server"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -10,11 +8,8 @@ import { FilterableArchive } from "@/components/filterable-archive"
 import { RelatedContentSectionsWithStats } from "@/components/related-content-with-stats"
 import { toArchiveItem } from "@/lib/archive"
 import { getCollection, type ContentDocument } from "@/lib/content"
-import { getPageViewStoreCached } from "@/lib/page-views"
-import { attachViewStats } from "@/lib/page-views/ranking"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { rankItemsWithLiveStats } from "@/lib/page-views/live"
 import { getRelatedForTopic } from "@/lib/related-content"
-import type { RelatedContent } from "@/lib/related-content"
 import { buildPageMetadata } from "@/lib/seo"
 import {
 	serviceCategories,
@@ -80,10 +75,7 @@ async function RankedCategoryArchive({
 	contentCategory: string
 	services: ContentDocument[]
 }) {
-	await connection()
-	const today = utcDayNow()
-	const store = await getPageViewStoreCached()
-	const items = attachViewStats(
+	const items = await rankItemsWithLiveStats(
 		services.map((service) =>
 			toArchiveItem(
 				service,
@@ -91,9 +83,7 @@ async function RankedCategoryArchive({
 				service.category ?? contentCategory,
 			),
 		),
-		store,
 		"service",
-		today,
 	)
 
 	return (
@@ -106,48 +96,6 @@ async function RankedCategoryArchive({
 			showFilters={false}
 			variant="service"
 		/>
-	)
-}
-
-async function ServiceCategoryBody({
-	category,
-	services,
-	related,
-}: {
-	category: (typeof serviceCategories)[ServiceCategorySlug]
-	services: ContentDocument[]
-	related: RelatedContent
-}) {
-	return (
-		<main id="main-content">
-			<ContentHero
-				description={category.description}
-				eyebrow={`${services.length} services`}
-				image={category.image}
-				imageAlt={category.label}
-				parent={{ href: "/services", label: "Services" }}
-				title={`${category.label} Services`}
-			/>
-			<Suspense
-				fallback={
-					<section className="container-shell section-y">
-						Loading services…
-					</section>
-				}
-			>
-				<RankedCategoryArchive
-					contentCategory={category.contentCategory}
-					label={category.label}
-					services={services}
-				/>
-			</Suspense>
-			<RelatedContentSectionsWithStats
-				postsTitle="Related expert tips"
-				related={related}
-				servicesTitle="Related services"
-			/>
-			<ContactCta />
-		</main>
 	)
 }
 
@@ -164,12 +112,26 @@ export default async function ServiceCategoryPage({
 	const data = await getServiceCategoryData(slug as ServiceCategorySlug)
 
 	return (
-		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<ServiceCategoryBody
-				category={data.category}
-				related={data.related}
+		<main id="main-content">
+			<ContentHero
+				description={data.category.description}
+				eyebrow={`${data.services.length} services`}
+				image={data.category.image}
+				imageAlt={data.category.label}
+				parent={{ href: "/services", label: "Services" }}
+				title={`${data.category.label} Services`}
+			/>
+			<RankedCategoryArchive
+				contentCategory={data.category.contentCategory}
+				label={data.category.label}
 				services={data.services}
 			/>
-		</Suspense>
+			<RelatedContentSectionsWithStats
+				postsTitle="Related expert tips"
+				related={data.related}
+				servicesTitle="Related services"
+			/>
+			<ContactCta />
+		</main>
 	)
 }

--- a/app/service-category/[slug]/page.tsx
+++ b/app/service-category/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
+import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -121,11 +122,19 @@ export default async function ServiceCategoryPage({
 				parent={{ href: "/services", label: "Services" }}
 				title={`${data.category.label} Services`}
 			/>
-			<RankedCategoryArchive
-				contentCategory={data.category.contentCategory}
-				label={data.category.label}
-				services={data.services}
-			/>
+			<Suspense
+				fallback={
+					<section className="container-shell section-y">
+						Loading services…
+					</section>
+				}
+			>
+				<RankedCategoryArchive
+					contentCategory={data.category.contentCategory}
+					label={data.category.label}
+					services={data.services}
+				/>
+			</Suspense>
 			<RelatedContentSectionsWithStats
 				postsTitle="Related expert tips"
 				related={data.related}

--- a/app/service-offerings/[slug]/page.tsx
+++ b/app/service-offerings/[slug]/page.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
-import { connection } from "next/server"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 
 import { ServiceLandingPage } from "@/components/service-landing-page"
 import { getCollection, getDocument, type ContentDocument } from "@/lib/content"
-import {
-	getPageViewStoreCached,
-	getStatsForSlug,
-} from "@/lib/page-views"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { getLiveViewStats } from "@/lib/page-views/live"
 import { getRelatedForService } from "@/lib/related-content"
 import { getServiceImage } from "@/lib/service-images"
 import { buildPageMetadata } from "@/lib/seo"
@@ -46,23 +40,6 @@ async function getRelatedCached(service: ContentDocument) {
 	return getRelatedForService(service)
 }
 
-async function RelatedServicePage({ service }: { service: ContentDocument }) {
-	const related = await getRelatedCached(service)
-
-	await connection()
-	const today = utcDayNow()
-	const store = await getPageViewStoreCached()
-	const viewStats = getStatsForSlug(store, "service", service.slug, today)
-
-	return (
-		<ServiceLandingPage
-			related={related}
-			service={service}
-			viewStats={viewStats}
-		/>
-	)
-}
-
 export default async function ServiceOfferingPage({
 	params,
 }: {
@@ -73,9 +50,14 @@ export default async function ServiceOfferingPage({
 
 	if (!service) notFound()
 
+	const related = await getRelatedCached(service)
+	const viewStats = await getLiveViewStats("service", service.slug)
+
 	return (
-		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<RelatedServicePage service={service} />
-		</Suspense>
+		<ServiceLandingPage
+			related={related}
+			service={service}
+			viewStats={viewStats}
+		/>
 	)
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -48,19 +47,13 @@ export default function ServicesPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<div className="container-shell section-y">Loading services…</div>
-				}
-			>
-				<RankedContentArchive
-					allLabel="All services"
-					emptyLabel="No services in this category."
-					noun={{ singular: "service", plural: "services" }}
-					pageSize={12}
-					variant="service"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="All services"
+				emptyLabel="No services in this category."
+				noun={{ singular: "service", plural: "services" }}
+				pageSize={12}
+				variant="service"
+			/>
 
 			<ContactCta
 				description="Call or message us. We will diagnose the problem and point you to the right service with no pressure."

--- a/app/services/popular/page.tsx
+++ b/app/services/popular/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -56,21 +55,15 @@ export default function PopularServicesPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<div className="container-shell section-y">Loading services…</div>
-				}
-			>
-				<RankedContentArchive
-					allLabel="Most popular services"
-					emptyLabel="No services in this category."
-					lockedSort
-					noun={{ singular: "service", plural: "services" }}
-					pageSize={12}
-					sort="popular"
-					variant="service"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="Most popular services"
+				emptyLabel="No services in this category."
+				lockedSort
+				noun={{ singular: "service", plural: "services" }}
+				pageSize={12}
+				sort="popular"
+				variant="service"
+			/>
 
 			<ContactCta title="Looking for a specific repair?" />
 		</main>

--- a/app/services/trending/page.tsx
+++ b/app/services/trending/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import type { Route } from "next"
 import Link from "next/link"
-import { Suspense } from "react"
 
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
@@ -57,21 +56,15 @@ export default function TrendingServicesPage() {
 				</div>
 			</section>
 
-			<Suspense
-				fallback={
-					<div className="container-shell section-y">Loading services…</div>
-				}
-			>
-				<RankedContentArchive
-					allLabel="Trending services"
-					emptyLabel="No services in this category."
-					lockedSort
-					noun={{ singular: "service", plural: "services" }}
-					pageSize={12}
-					sort="trending"
-					variant="service"
-				/>
-			</Suspense>
+			<RankedContentArchive
+				allLabel="Trending services"
+				emptyLabel="No services in this category."
+				lockedSort
+				noun={{ singular: "service", plural: "services" }}
+				pageSize={12}
+				sort="trending"
+				variant="service"
+			/>
 
 			<ContactCta title="Seeing the same problem at your place?" />
 		</main>

--- a/app/tag/[slug]/page.tsx
+++ b/app/tag/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next"
 import { cacheLife, cacheTag } from "next/cache"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 
 import { ArticleArchive } from "@/components/article-archive"
 import { getCollection, taxonomySlug } from "@/lib/content"
@@ -98,9 +97,5 @@ export default async function TagPage({
 
 	if (!matched.length) notFound()
 
-	return (
-		<Suspense fallback={<main id="main-content" className="min-h-[50vh]" />}>
-			<TagArchive slug={slug} />
-		</Suspense>
-	)
+	return <TagArchive slug={slug} />
 }

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -1,15 +1,10 @@
-import { connection } from "next/server"
-import { Suspense } from "react"
-
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { FilterableArchive } from "@/components/filterable-archive"
 import { RelatedContentSectionsWithStats } from "@/components/related-content-with-stats"
 import { toArchiveItem } from "@/lib/archive"
 import type { ContentDocument } from "@/lib/content"
-import { getPageViewStoreCached } from "@/lib/page-views"
-import { attachViewStats } from "@/lib/page-views/ranking"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { rankItemsWithLiveStats } from "@/lib/page-views/live"
 import type { RelatedContent } from "@/lib/related-content"
 
 async function RankedArticleArchive({
@@ -19,16 +14,11 @@ async function RankedArticleArchive({
 	title: string
 	posts: ContentDocument[]
 }) {
-	await connection()
-	const today = utcDayNow()
-	const store = await getPageViewStoreCached()
-	const items = attachViewStats(
+	const items = await rankItemsWithLiveStats(
 		posts.map((post) =>
 			toArchiveItem(post, `/${post.slug}`, post.category ?? "Expert Tips"),
 		),
-		store,
 		"tip",
-		today,
 	)
 
 	return (
@@ -65,15 +55,7 @@ export async function ArticleArchive({
 				parent={{ href: "/expert-tips", label: "Expert Tips" }}
 				title={title}
 			/>
-			<Suspense
-				fallback={
-					<section className="container-shell section-y">
-						Loading guides…
-					</section>
-				}
-			>
-				<RankedArticleArchive posts={posts} title={title} />
-			</Suspense>
+			<RankedArticleArchive posts={posts} title={title} />
 			{related ? (
 				<RelatedContentSectionsWithStats
 					postsTitle="More related guides"

--- a/components/article-archive.tsx
+++ b/components/article-archive.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react"
+
 import { ContactCta } from "@/components/contact-cta"
 import { ContentHero } from "@/components/content-hero"
 import { FilterableArchive } from "@/components/filterable-archive"
@@ -34,7 +36,7 @@ async function RankedArticleArchive({
 	)
 }
 
-export async function ArticleArchive({
+export function ArticleArchive({
 	title,
 	description,
 	posts,
@@ -55,7 +57,15 @@ export async function ArticleArchive({
 				parent={{ href: "/expert-tips", label: "Expert Tips" }}
 				title={title}
 			/>
-			<RankedArticleArchive posts={posts} title={title} />
+			<Suspense
+				fallback={
+					<section className="container-shell section-y">
+						Loading guides…
+					</section>
+				}
+			>
+				<RankedArticleArchive posts={posts} title={title} />
+			</Suspense>
 			{related ? (
 				<RelatedContentSectionsWithStats
 					postsTitle="More related guides"

--- a/components/ranked-content-archive.tsx
+++ b/components/ranked-content-archive.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react"
+
 import { FilterableArchive } from "@/components/filterable-archive"
 import { toArchiveItem, type ArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
@@ -25,7 +27,7 @@ async function tipItems() {
 	)
 }
 
-export async function RankedContentArchive({
+async function RankedArchiveBody({
 	variant,
 	sort = "default",
 	pageSize,
@@ -42,7 +44,6 @@ export async function RankedContentArchive({
 	emptyLabel: string
 	noun: { singular: string; plural: string }
 	showFilters?: boolean
-	/** When true, hide the sort control (dedicated popular/trending pages). */
 	lockedSort?: boolean
 }) {
 	const items: ArchiveItem[] =
@@ -62,5 +63,47 @@ export async function RankedContentArchive({
 			showSort={!lockedSort}
 			variant={variant}
 		/>
+	)
+}
+
+export function RankedContentArchive({
+	variant,
+	sort = "default",
+	pageSize,
+	allLabel,
+	emptyLabel,
+	noun,
+	showFilters = true,
+	lockedSort = false,
+}: {
+	variant: "service" | "tip"
+	sort?: ArchiveSort
+	pageSize: number
+	allLabel: string
+	emptyLabel: string
+	noun: { singular: string; plural: string }
+	showFilters?: boolean
+	/** When true, hide the sort control (dedicated popular/trending pages). */
+	lockedSort?: boolean
+}) {
+	/* Suspense is required for FilterableArchive's useSearchParams, but must
+	   not wrap the page hero (empty-main shells broke mobile navigation). */
+	return (
+		<Suspense
+			fallback={
+				<section className="container-shell section-y">Loading…</section>
+			}
+		>
+			<RankedArchiveBody
+				allLabel={allLabel}
+				emptyLabel={emptyLabel}
+				lockedSort={lockedSort}
+				noun={noun}
+				pageSize={pageSize}
+				showFilters={showFilters}
+				sort={sort}
+				variant={variant}
+			/>
+		</Suspense>
 	)
 }

--- a/components/ranked-content-archive.tsx
+++ b/components/ranked-content-archive.tsx
@@ -1,15 +1,11 @@
-import { connection } from "next/server"
-
 import { FilterableArchive } from "@/components/filterable-archive"
 import { toArchiveItem, type ArchiveItem } from "@/lib/archive"
 import { getCollection } from "@/lib/content"
-import { getPageViewStoreCached } from "@/lib/page-views"
 import {
-	attachViewStats,
 	sortArchiveItems,
 	type ArchiveSort,
 } from "@/lib/page-views/ranking"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { rankItemsWithLiveStats } from "@/lib/page-views/live"
 
 async function serviceItems() {
 	const services = await getCollection("services")
@@ -49,17 +45,10 @@ export async function RankedContentArchive({
 	/** When true, hide the sort control (dedicated popular/trending pages). */
 	lockedSort?: boolean
 }) {
-	/* View stats and trending windows are request-time (live JSON + utc day). */
-	await connection()
-	const today = utcDayNow()
-
 	const items: ArchiveItem[] =
 		variant === "service" ? await serviceItems() : await tipItems()
-	const store = await getPageViewStoreCached()
-	const withStats = attachViewStats(items, store, variant, today)
-	const ranked = lockedSort
-		? sortArchiveItems(withStats, sort)
-		: withStats
+	const withStats = await rankItemsWithLiveStats(items, variant)
+	const ranked = lockedSort ? sortArchiveItems(withStats, sort) : withStats
 
 	return (
 		<FilterableArchive

--- a/components/related-content-with-stats.tsx
+++ b/components/related-content-with-stats.tsx
@@ -1,10 +1,13 @@
-import { Suspense } from "react"
-
 import { RelatedContentSections } from "@/components/related-content"
 import { withRelatedViewStats } from "@/lib/page-views/attach-related"
 import type { RelatedContent } from "@/lib/related-content"
 
-async function RelatedContentSectionsLive({
+/**
+ * Related rails with minute-cached view stats.
+ * Stats refresh via cacheLife("minutes") without opting the page into
+ * request-time `connection()` (which broke mobile RSC navigations).
+ */
+export async function RelatedContentSectionsWithStats({
 	related,
 	servicesTitle,
 	postsTitle,
@@ -20,37 +23,5 @@ async function RelatedContentSectionsLive({
 			related={relatedWithStats}
 			servicesTitle={servicesTitle}
 		/>
-	)
-}
-
-/**
- * Prerender related rails without live view stats, then upgrade at request time.
- * Keeps Cache Components happy: utcDayNow() must not run during static prerender.
- */
-export function RelatedContentSectionsWithStats({
-	related,
-	servicesTitle,
-	postsTitle,
-}: {
-	related: RelatedContent
-	servicesTitle?: string
-	postsTitle?: string
-}) {
-	return (
-		<Suspense
-			fallback={
-				<RelatedContentSections
-					postsTitle={postsTitle}
-					related={related}
-					servicesTitle={servicesTitle}
-				/>
-			}
-		>
-			<RelatedContentSectionsLive
-				postsTitle={postsTitle}
-				related={related}
-				servicesTitle={servicesTitle}
-			/>
-		</Suspense>
 	)
 }

--- a/components/site-header-mobile-menu.tsx
+++ b/components/site-header-mobile-menu.tsx
@@ -3,6 +3,7 @@
 import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import type { ReactNode } from "react"
 
 import { ArrowRight, Phone } from "@/components/icons"
@@ -10,7 +11,6 @@ import { buttonVariants } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import {
 	Sheet,
-	SheetClose,
 	SheetContent,
 	SheetDescription,
 	SheetFooter,
@@ -32,32 +32,43 @@ function MobileNavLink({
 	label,
 	description,
 	compact = false,
-}: NavLink & { compact?: boolean }) {
+	onNavigate,
+}: NavLink & { compact?: boolean; onNavigate: () => void }) {
+	const router = useRouter()
+
 	return (
-		<SheetClose asChild>
-			<Link
+		<Link
+			className={cn(
+				"hover:bg-muted focus-visible:ring-ring block rounded-md px-3 transition-colors outline-none focus-visible:ring-2",
+				compact ? "py-2" : "py-2.5",
+			)}
+			href={href as Route}
+			prefetch
+			onClick={(event) => {
+				/*
+				  Radix SheetClose + Next Link races the dialog unmount against
+				  soft navigation, so many taps close the menu and go nowhere.
+				  Close first, then push explicitly.
+				*/
+				event.preventDefault()
+				onNavigate()
+				router.push(href as Route)
+			}}
+		>
+			<span
 				className={cn(
-					"hover:bg-muted focus-visible:ring-ring block rounded-md px-3 transition-colors outline-none focus-visible:ring-2",
-					compact ? "py-2" : "py-2.5",
+					"text-foreground block font-bold tracking-[-0.02em]",
+					compact ? "text-[0.9375rem]" : "text-base",
 				)}
-				href={href as Route}
-				prefetch
 			>
-				<span
-					className={cn(
-						"text-foreground block font-bold tracking-[-0.02em]",
-						compact ? "text-[0.9375rem]" : "text-base",
-					)}
-				>
-					{label}
+				{label}
+			</span>
+			{description && !compact ? (
+				<span className="text-muted-foreground mt-0.5 block text-sm leading-snug">
+					{description}
 				</span>
-				{description && !compact ? (
-					<span className="text-muted-foreground mt-0.5 block text-sm leading-snug">
-						{description}
-					</span>
-				) : null}
-			</Link>
-		</SheetClose>
+			) : null}
+		</Link>
 	)
 }
 
@@ -94,10 +105,17 @@ export function SiteHeaderMobileMenu({
 	open: boolean
 	onOpenChange: (open: boolean) => void
 }) {
+	const router = useRouter()
+	const closeMenu = () => onOpenChange(false)
+
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
-			<SheetContent side="right" className="bg-card gap-0">
-				<SheetHeader className="shadow-[inset_0_-1px_0_0_var(--border)]">
+			{/*
+			  h-dvh + min-h-0 keeps the scroll region between header/footer so
+			  lower links are not trapped under the sticky CTA bar.
+			*/}
+			<SheetContent side="right" className="bg-card h-dvh gap-0 overflow-hidden">
+				<SheetHeader className="shrink-0 shadow-[inset_0_-1px_0_0_var(--border)]">
 					<div className="flex items-center gap-3">
 						<Image
 							alt="Wade's Plumbing & Septic logo"
@@ -123,7 +141,7 @@ export function SiteHeaderMobileMenu({
 				  Descriptions are omitted so the sheet stays scannable.
 				*/}
 				<nav
-					className="flex-1 overflow-y-auto px-2 pb-4"
+					className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 pb-4"
 					aria-label="Mobile navigation"
 				>
 					<section className="pt-2">
@@ -131,7 +149,11 @@ export function SiteHeaderMobileMenu({
 						<ul>
 							{mobilePrimaryLinks.map((item) => (
 								<li key={item.href}>
-									<MobileNavLink compact {...item} />
+									<MobileNavLink
+										compact
+										onNavigate={closeMenu}
+										{...item}
+									/>
 								</li>
 							))}
 						</ul>
@@ -147,20 +169,22 @@ export function SiteHeaderMobileMenu({
 										compact
 										href={item.href}
 										label={item.label}
+										onNavigate={closeMenu}
 									/>
 								</li>
 							))}
 							<li>
-								<SheetClose asChild>
-									<Link
-										className="text-primary hover:bg-muted focus-visible:ring-ring flex items-center gap-1.5 rounded-md px-3 py-2 text-[0.9375rem] font-bold outline-none focus-visible:ring-2"
-										href={"/services" as Route}
-										prefetch
-									>
-										Browse all services
-										<ArrowRight aria-hidden="true" className="size-3.5" />
-									</Link>
-								</SheetClose>
+								<button
+									type="button"
+									className="text-primary hover:bg-muted focus-visible:ring-ring flex w-full items-center gap-1.5 rounded-md px-3 py-2 text-left text-[0.9375rem] font-bold outline-none focus-visible:ring-2"
+									onClick={() => {
+										closeMenu()
+										router.push("/services")
+									}}
+								>
+									Browse all services
+									<ArrowRight aria-hidden="true" className="size-3.5" />
+								</button>
 							</li>
 						</ul>
 					</MobileNavSection>
@@ -175,6 +199,7 @@ export function SiteHeaderMobileMenu({
 											compact
 											href={item.href}
 											label={item.label}
+											onNavigate={closeMenu}
 										/>
 									</li>
 								))}
@@ -185,14 +210,19 @@ export function SiteHeaderMobileMenu({
 						<ul className="grid grid-cols-2 gap-x-1">
 							{mobileCompanyLinks.map((item) => (
 								<li key={item.href}>
-									<MobileNavLink compact href={item.href} label={item.label} />
+									<MobileNavLink
+										compact
+										href={item.href}
+										label={item.label}
+										onNavigate={closeMenu}
+									/>
 								</li>
 							))}
 						</ul>
 					</MobileNavSection>
 				</nav>
 
-				<SheetFooter className="gap-2">
+				<SheetFooter className="shrink-0 gap-2">
 					<a
 						className={cn(buttonVariants({ size: "lg" }), "w-full gap-2")}
 						href={siteConfig.phoneHref}
@@ -200,18 +230,19 @@ export function SiteHeaderMobileMenu({
 						<Phone aria-hidden="true" />
 						Call {siteConfig.phone}
 					</a>
-					<SheetClose asChild>
-						<Link
-							className={cn(
-								buttonVariants({ variant: "outline", size: "lg" }),
-								"w-full",
-							)}
-							href={"/contact" as Route}
-							prefetch
-						>
-							Get a Free Quote
-						</Link>
-					</SheetClose>
+					<button
+						type="button"
+						className={cn(
+							buttonVariants({ variant: "outline", size: "lg" }),
+							"w-full",
+						)}
+						onClick={() => {
+							closeMenu()
+							router.push("/contact")
+						}}
+					>
+						Get a Free Quote
+					</button>
 				</SheetFooter>
 			</SheetContent>
 		</Sheet>

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -19,7 +19,7 @@ export function SheetOverlay({
 	return (
 		<SheetPrimitive.Overlay
 			className={cn(
-				"bg-ink/70 data-[state=open]:animate-fade fixed inset-0 z-50",
+				"bg-ink/70 data-[state=open]:animate-fade fixed inset-0 z-[60]",
 				className,
 			)}
 			{...props}
@@ -28,7 +28,7 @@ export function SheetOverlay({
 }
 
 const sheetVariants = cva(
-	"fixed z-50 flex flex-col gap-4 bg-card text-card-foreground shadow-[var(--shadow-edge)] transition ease-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
+	"fixed z-[60] flex flex-col gap-4 bg-card text-card-foreground shadow-[var(--shadow-edge)] transition ease-out data-[state=closed]:duration-200 data-[state=open]:duration-300",
 	{
 		variants: {
 			side: {

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,6 +1,13 @@
-import { defineNodeInstrumentation } from 'evlog/next/instrumentation'
+/**
+ * Evlog's defineNodeInstrumentation dynamically imports
+ * `evlog/next/instrumentation/create` with webpackIgnore, so Vercel file
+ * tracing omits that module and register() fails on every Node serverless
+ * cold start. That collapses route handlers (including /api/search-index)
+ * onto the static /500 page.
+ *
+ * Keep hooks as no-ops until evlog ships a statically bundleable entry, or
+ * we switch to a drain that does not need Node instrumentation.
+ */
+export async function register() {}
 
-export const { register, onRequestError } = defineNodeInstrumentation({
-  service: 'wades-plumbing-and-septic',
-  captureOutput: true,
-})
+export async function onRequestError() {}

--- a/lib/page-views/attach-related.ts
+++ b/lib/page-views/attach-related.ts
@@ -1,23 +1,11 @@
 import "server-only"
 
-import { connection } from "next/server"
-
 import type { RelatedContent } from "@/lib/related-content"
-import {
-	attachViewStats,
-	getPageViewStoreCached,
-} from "@/lib/page-views"
-import { utcDayNow } from "@/lib/page-views/stats"
+import { withRelatedViewStatsCached } from "@/lib/page-views/live"
 
-/** Attach live view stats to related rails (services + tips). Request-time only. */
+/** Attach live view stats to related rails (services + tips). */
 export async function withRelatedViewStats(
 	related: RelatedContent,
 ): Promise<RelatedContent> {
-	await connection()
-	const store = await getPageViewStoreCached()
-	const today = utcDayNow()
-	return {
-		services: attachViewStats(related.services, store, "service", today),
-		posts: attachViewStats(related.posts, store, "tip", today),
-	}
+	return withRelatedViewStatsCached(related)
 }

--- a/lib/page-views/live.ts
+++ b/lib/page-views/live.ts
@@ -1,0 +1,63 @@
+import "server-only"
+
+import { cacheLife, cacheTag } from "next/cache"
+
+import type { ArchiveItem } from "@/lib/archive"
+import {
+	attachViewStats,
+	getPageViewStoreCached,
+	getStatsForSlug,
+	type RankedArchiveItem,
+} from "@/lib/page-views"
+import { utcDayNow } from "@/lib/page-views/stats"
+import type { PageViewKind, PageViewStats } from "@/lib/page-views/types"
+import type { RelatedContent } from "@/lib/related-content"
+
+/**
+ * Live view stats without `connection()`.
+ *
+ * `utcDayNow()` is closed over inside `"use cache"` + `cacheLife("minutes")`,
+ * so pages stay fully prerenderable. Putting `connection()` around whole page
+ * trees produced truncated HTML shells (no Flight payload) and React #412
+ * "Connection closed" on mobile navigations.
+ */
+export async function getLiveViewStats(
+	kind: PageViewKind,
+	slug: string,
+): Promise<PageViewStats> {
+	"use cache"
+	cacheTag("page-views")
+	cacheLife("minutes")
+
+	const today = utcDayNow()
+	const store = await getPageViewStoreCached()
+	return getStatsForSlug(store, kind, slug, today)
+}
+
+export async function rankItemsWithLiveStats(
+	items: ArchiveItem[],
+	kind: PageViewKind,
+): Promise<RankedArchiveItem[]> {
+	"use cache"
+	cacheTag("page-views")
+	cacheLife("minutes")
+
+	const today = utcDayNow()
+	const store = await getPageViewStoreCached()
+	return attachViewStats(items, store, kind, today)
+}
+
+export async function withRelatedViewStatsCached(
+	related: RelatedContent,
+): Promise<RelatedContent> {
+	"use cache"
+	cacheTag("page-views")
+	cacheLife("minutes")
+
+	const today = utcDayNow()
+	const store = await getPageViewStoreCached()
+	return {
+		services: attachViewStats(related.services, store, "service", today),
+		posts: attachViewStats(related.posts, store, "tip", today),
+	}
+}

--- a/lib/page-views/stats.ts
+++ b/lib/page-views/stats.ts
@@ -11,7 +11,11 @@ export function utcDay(date: Date) {
 	return date.toISOString().slice(0, 10)
 }
 
-/** Request-time helper. Do not call during static prerender. */
+/**
+ * UTC calendar day. Prefer calling inside `"use cache"` + `cacheLife(...)`
+ * so the value is closed over for that cache entry. Avoid pairing with
+ * `connection()` around full page trees (truncated prerender shells).
+ */
 export function utcDayNow() {
 	return utcDay(new Date())
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two production outages that made the mobile site feel broken:

1. **Mobile menu / soft navigation** — Many routes were serving truncated RSC shells (empty `<main>`, missing Flight payload), which caused React error #412 (“Connection closed”) and made taps appear to do nothing. Root cause was wrapping full page trees in `await connection()` plus empty Suspense fallbacks under `cacheComponents`. Also hardened the mobile sheet (close-then-navigate, scrollable body, higher z-index).

2. **Global search “temporarily unavailable”** — `/api/search-index` (and other Node route handlers like `/api/page-view`, `/llms.txt`) returned the static `/500` page on production. Root cause was `evlog`’s `defineNodeInstrumentation`, which dynamically imports `evlog/next/instrumentation/create` with `webpackIgnore`, so Vercel file tracing omits that module and `register()` fails on serverless cold starts. Instrumentation is now a no-op; search/llms handlers no longer wrap with `withEvlog`.

## Test plan

- [ ] Open site on a phone (or narrow viewport): mobile menu Services, Service Areas, Expert Tips, Contact, and nested service links navigate correctly
- [ ] Spot-check previously broken deep pages (service offering, category, tip) load full content (real H1, no blank main)
- [ ] Open global search: index loads, results appear (no “Search is temporarily unavailable”)
- [ ] `GET /api/search-index` returns 200 JSON
- [ ] `GET /llms.txt` returns 200 plain text
- [ ] `POST /api/page-view` no longer matches `/500`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

