### PR TITLE
Add spam-resistant contacts, vCard, and virtual business card

### DIFF
--- a/app/contact.vcf/route.ts
+++ b/app/contact.vcf/route.ts
@@ -1,0 +1,19 @@
+import { buildBusinessVCard } from "@/lib/vcard"
+
+/**
+ * Virtual business card for Wade's Plumbing & Septic.
+ * Opening this on a phone typically launches Add Contact with phone, email,
+ * address, website, and logo already filled in (iOS, Android, and desktop).
+ */
+export function GET() {
+	const body = buildBusinessVCard()
+
+	return new Response(body, {
+		headers: {
+			"Content-Type": "text/vcard; charset=utf-8",
+			"Content-Disposition":
+				'inline; filename="Wades-Plumbing-and-Septic.vcf"',
+			"Cache-Control": "public, max-age=86400, stale-while-revalidate=604800",
+		},
+	})
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,13 +9,15 @@ import {
 	Droplets,
 	Gauge,
 	Home,
-	Phone,
 	ShieldCheck,
 	Wrench,
 } from "@/components/icons"
 
+import { CallButton } from "@/components/call-button"
 import { ContactCta } from "@/components/contact-cta"
 import { JsonLd } from "@/components/json-ld"
+import { ProtectedPhoneText } from "@/components/protected-contact"
+import { contactInfo } from "@/lib/contact"
 
 const HomeFaq = dynamic(() =>
 	import("@/components/home-faq").then((mod) => mod.HomeFaq),
@@ -29,7 +31,6 @@ import {
 	CardTitle,
 } from "@/components/ui/card"
 import { buildPageMetadata } from "@/lib/seo"
-import { siteConfig } from "@/lib/site"
 import { cn } from "@/lib/utils"
 
 export const metadata: Metadata = buildPageMetadata({
@@ -296,16 +297,12 @@ export default function HomePage() {
 						</p>
 
 						<div className="flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-							<a
-								className={cn(
-									buttonVariants({ size: "xl" }),
-									"w-full sm:w-auto",
-								)}
-								href={siteConfig.phoneHref}
-							>
-								<Phone aria-hidden="true" />
-								Call {siteConfig.phone}
-							</a>
+							<CallButton
+								className="w-full sm:w-auto"
+								desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+								mobileLabel="Save contact"
+								size="xl"
+							/>
 							<Link
 								className={cn(
 									buttonVariants({ variant: "inverse", size: "xl" }),
@@ -410,16 +407,12 @@ export default function HomePage() {
 								</div>
 							))}
 							<div className="flex w-full flex-col gap-3 sm:col-span-2 sm:flex-row">
-								<a
-									className={cn(
-										buttonVariants({ size: "xl" }),
-										"w-full sm:w-auto",
-									)}
-									href={siteConfig.phoneHref}
-								>
-									<Phone aria-hidden="true" />
-									Call to schedule: {siteConfig.phone}
-								</a>
+								<CallButton
+									className="w-full sm:w-auto"
+									desktopLabel={`Call to schedule: ${contactInfo.phoneDisplay}`}
+									mobileLabel="Save contact"
+									size="xl"
+								/>
 								<Link
 									className={cn(
 										buttonVariants({ variant: "outline", size: "xl" }),
@@ -684,12 +677,7 @@ export default function HomePage() {
 						</h2>
 						<p className="type-lead">
 							Do not see your question? Call{" "}
-							<a
-								className="text-primary font-bold underline-offset-2 hover:underline"
-								href={siteConfig.phoneHref}
-							>
-								{siteConfig.phone}
-							</a>{" "}
+							<ProtectedPhoneText className="text-primary font-bold underline-offset-2 hover:underline" />{" "}
 							and talk to someone who understands the work.
 						</p>
 					</div>

--- a/components/call-button.tsx
+++ b/components/call-button.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { IdentificationCard, Phone } from "@/components/icons"
+import { Phone } from "@/components/icons"
 
 import { ProtectedContactLink } from "@/components/protected-contact"
+import { SaveContactButton } from "@/components/save-contact-button"
 import { buttonVariants } from "@/components/ui/button"
 import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
@@ -11,9 +12,8 @@ import { cn } from "@/lib/utils"
 type ButtonSize = "default" | "sm" | "lg" | "xl" | "icon"
 
 /**
- * Call CTA. By default phones see "Save contact" (vCard / Add Contact) and
- * desktop sees dial. Prefer is implemented with CSS dual links so there is no
- * matchMedia effect or hydration mismatch.
+ * Call CTA. By default phones see "Save contact" (vCard, then call prompt)
+ * and desktop sees dial.
  */
 export function CallButton({
 	className,
@@ -51,27 +51,19 @@ export function CallButton({
 
 	if (prefer === "vcard") {
 		return (
-			<ProtectedContactLink
-				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
-				className={styles}
-				kind="vcard"
-			>
-				{showIcon ? <IdentificationCard aria-hidden="true" /> : null}
+			<SaveContactButton className={className} size={size} variant={variant}>
 				{mobileLabel}
-			</ProtectedContactLink>
+			</SaveContactButton>
 		)
 	}
 
 	return (
 		<>
-			<ProtectedContactLink
-				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
-				className={cn(styles, "sm:hidden")}
-				kind="vcard"
-			>
-				{showIcon ? <IdentificationCard aria-hidden="true" /> : null}
-				{mobileLabel}
-			</ProtectedContactLink>
+			<span className="sm:hidden">
+				<SaveContactButton className={className} size={size} variant={variant}>
+					{mobileLabel}
+				</SaveContactButton>
+			</span>
 			<ProtectedContactLink
 				ariaLabel={`Call ${contactInfo.phoneDisplay}`}
 				className={cn(styles, "hidden sm:inline-flex")}
@@ -84,17 +76,24 @@ export function CallButton({
 	)
 }
 
-/** Icon-only header call control with the same mobile vCard behavior. */
+/** Icon-only header call control with the same mobile vCard + call-prompt behavior. */
 export function CallIconButton({ className }: { className?: string }) {
 	return (
 		<>
-			<ProtectedContactLink
-				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
-				className={cn(className, "sm:hidden")}
-				kind="vcard"
-			>
-				<Phone aria-hidden="true" className="size-5" />
-			</ProtectedContactLink>
+			<span className="sm:hidden">
+				<SaveContactButton
+					className={cn(
+						className,
+						"inline-flex size-11 items-center justify-center p-0",
+					)}
+					showIcon={false}
+					size="icon"
+					variant="ghost"
+				>
+					<span className="sr-only">Save contact</span>
+					<Phone aria-hidden="true" className="size-5" />
+				</SaveContactButton>
+			</span>
 			<ProtectedContactLink
 				ariaLabel={`Call ${contactInfo.phoneDisplay}`}
 				className={cn(className, "hidden sm:inline-flex")}

--- a/components/call-button.tsx
+++ b/components/call-button.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { IdentificationCard, Phone } from "@/components/icons"
+
+import { ProtectedContactLink } from "@/components/protected-contact"
+import { buttonVariants } from "@/components/ui/button"
+import { contactInfo } from "@/lib/contact"
+import { cn } from "@/lib/utils"
+
+type ButtonSize = "default" | "sm" | "lg" | "xl" | "icon"
+
+/**
+ * Call CTA. By default phones see "Save contact" (vCard / Add Contact) and
+ * desktop sees dial. Prefer is implemented with CSS dual links so there is no
+ * matchMedia effect or hydration mismatch.
+ */
+export function CallButton({
+	className,
+	size = "xl",
+	variant = "default",
+	showIcon = true,
+	prefer = "auto",
+	desktopLabel,
+	mobileLabel = "Save contact",
+}: {
+	className?: string
+	size?: ButtonSize
+	variant?: "default" | "secondary" | "inverse" | "outline" | "ghost"
+	showIcon?: boolean
+	/** auto: vCard on small viewports, dial from sm up. */
+	prefer?: "auto" | "dial" | "vcard"
+	desktopLabel?: ReactNode
+	mobileLabel?: ReactNode
+}) {
+	const styles = cn(buttonVariants({ size, variant }), className)
+	const dialLabel = desktopLabel ?? `Call ${contactInfo.phoneDisplay}`
+
+	if (prefer === "dial") {
+		return (
+			<ProtectedContactLink
+				ariaLabel={`Call ${contactInfo.phoneDisplay}`}
+				className={styles}
+				kind="phone"
+			>
+				{showIcon ? <Phone aria-hidden="true" /> : null}
+				{dialLabel}
+			</ProtectedContactLink>
+		)
+	}
+
+	if (prefer === "vcard") {
+		return (
+			<ProtectedContactLink
+				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
+				className={styles}
+				kind="vcard"
+			>
+				{showIcon ? <IdentificationCard aria-hidden="true" /> : null}
+				{mobileLabel}
+			</ProtectedContactLink>
+		)
+	}
+
+	return (
+		<>
+			<ProtectedContactLink
+				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
+				className={cn(styles, "sm:hidden")}
+				kind="vcard"
+			>
+				{showIcon ? <IdentificationCard aria-hidden="true" /> : null}
+				{mobileLabel}
+			</ProtectedContactLink>
+			<ProtectedContactLink
+				ariaLabel={`Call ${contactInfo.phoneDisplay}`}
+				className={cn(styles, "hidden sm:inline-flex")}
+				kind="phone"
+			>
+				{showIcon ? <Phone aria-hidden="true" /> : null}
+				{dialLabel}
+			</ProtectedContactLink>
+		</>
+	)
+}
+
+/** Icon-only header call control with the same mobile vCard behavior. */
+export function CallIconButton({ className }: { className?: string }) {
+	return (
+		<>
+			<ProtectedContactLink
+				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
+				className={cn(className, "sm:hidden")}
+				kind="vcard"
+			>
+				<Phone aria-hidden="true" className="size-5" />
+			</ProtectedContactLink>
+			<ProtectedContactLink
+				ariaLabel={`Call ${contactInfo.phoneDisplay}`}
+				className={cn(className, "hidden sm:inline-flex")}
+				kind="phone"
+			>
+				<Phone aria-hidden="true" className="size-5" />
+			</ProtectedContactLink>
+		</>
+	)
+}

--- a/components/contact-cta.tsx
+++ b/components/contact-cta.tsx
@@ -1,8 +1,13 @@
 import Link from "next/link"
 import { ArrowRight, Clock, Mail, Phone } from "@/components/icons"
 
+import { CallButton } from "@/components/call-button"
+import {
+	ProtectedContactLink,
+	ProtectedEmailText,
+} from "@/components/protected-contact"
 import { buttonVariants } from "@/components/ui/button"
-import { siteConfig } from "@/lib/site"
+import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
 
 export function ContactCta({
@@ -58,26 +63,23 @@ export function ContactCta({
 						{description}
 					</p>
 					{compact ? (
-						<a
+						<ProtectedContactLink
 							className="text-primary-bright inline-flex items-center gap-2 text-sm font-bold transition-colors hover:text-white"
-							href={siteConfig.phoneHref}
+							kind="phone"
 						>
-							<Phone className="size-4 shrink-0" aria-hidden="true" />
-							{siteConfig.phone}
-						</a>
+							<Phone aria-hidden="true" className="size-4 shrink-0" />
+							{contactInfo.phoneDisplay}
+						</ProtectedContactLink>
 					) : (
 						<div className="text-on-dark-muted flex flex-wrap gap-x-6 gap-y-2 text-sm">
 							<span className="inline-flex items-center gap-2">
 								<Clock className="text-primary-bright size-4 shrink-0" />
-								{siteConfig.hours}
+								{contactInfo.hours}
 							</span>
-							<a
-								className="inline-flex items-center gap-2 transition-colors hover:text-white"
-								href={`mailto:${siteConfig.email}`}
-							>
+							<span className="inline-flex items-center gap-2">
 								<Mail className="text-primary-bright size-4 shrink-0" />
-								{siteConfig.email}
-							</a>
+								<ProtectedEmailText className="transition-colors hover:text-white" />
+							</span>
 						</div>
 					)}
 				</div>
@@ -89,16 +91,12 @@ export function ContactCta({
 					)}
 				>
 					{includeCall ? (
-						<a
-							className={cn(
-								buttonVariants({ size: compact ? "lg" : "xl" }),
-								actionWidth,
-							)}
-							href={siteConfig.phoneHref}
-						>
-							<Phone aria-hidden="true" />
-							Call {siteConfig.phone}
-						</a>
+						<CallButton
+							className={actionWidth}
+							desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+							mobileLabel="Save contact"
+							size={compact ? "lg" : "xl"}
+						/>
 					) : null}
 					<Link
 						className={cn(

--- a/components/content-conversion-cta.tsx
+++ b/components/content-conversion-cta.tsx
@@ -1,10 +1,12 @@
 import type { Route } from "next"
 import Link from "next/link"
-import { ArrowRight, Phone } from "@/components/icons"
+import { ArrowRight } from "@/components/icons"
 
+import { CallButton } from "@/components/call-button"
+import { ProtectedContactLink } from "@/components/protected-contact"
 import { buttonVariants } from "@/components/ui/button"
 import type { ContentConversion } from "@/lib/content-conversion"
-import { siteConfig } from "@/lib/site"
+import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
 
 export function ContentConversionCta({
@@ -14,9 +16,11 @@ export function ContentConversionCta({
 	conversion: ContentConversion
 	/** Override the secondary CTA (defaults to Contact / Get a Free Quote). */
 	secondaryAction?: {
-		href: string
+		href?: string
 		label: string
 		external?: boolean
+		/** Protected email link (no mailto: in server HTML). */
+		contact?: "email" | "phone" | "vcard"
 	}
 }) {
 	const secondary = secondaryAction ?? {
@@ -29,9 +33,9 @@ export function ContentConversionCta({
 		"w-full sm:w-auto",
 	)
 	const secondaryIsExternal =
-		secondary.external ||
-		secondary.href.startsWith("mailto:") ||
-		secondary.href.startsWith("tel:")
+		Boolean(secondary.external) ||
+		Boolean(secondary.href?.startsWith("mailto:")) ||
+		Boolean(secondary.href?.startsWith("tel:"))
 
 	return (
 		<section className="surface-hero tex-grid tex-glow overflow-hidden">
@@ -48,14 +52,21 @@ export function ContentConversionCta({
 					</div>
 
 					<div className="reveal mt-8 flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:items-center">
-						<a
-							className={cn(buttonVariants({ size: "xl" }), "w-full sm:w-auto")}
-							href={siteConfig.phoneHref}
-						>
-							<Phone aria-hidden="true" />
-							Call {siteConfig.phone}
-						</a>
-						{secondaryIsExternal ? (
+						<CallButton
+							className="w-full sm:w-auto"
+							desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+							mobileLabel="Save contact"
+							size="xl"
+						/>
+						{secondary.contact ? (
+							<ProtectedContactLink
+								className={secondaryClassName}
+								kind={secondary.contact}
+							>
+								{secondary.label}
+								<ArrowRight aria-hidden="true" />
+							</ProtectedContactLink>
+						) : secondaryIsExternal && secondary.href ? (
 							<a className={secondaryClassName} href={secondary.href}>
 								{secondary.label}
 								<ArrowRight aria-hidden="true" />
@@ -63,7 +74,7 @@ export function ContentConversionCta({
 						) : (
 							<Link
 								className={secondaryClassName}
-								href={secondary.href as Route}
+								href={(secondary.href ?? "/contact") as Route}
 								prefetch
 							>
 								{secondary.label}
@@ -116,10 +127,10 @@ export function ContentConversionCta({
 						<span className="ml-2 text-white/85">5-star local reviews</span>
 					</p>
 					<p className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
-						{siteConfig.licenses}
+						{contactInfo.licenses}
 					</p>
 					<p className="text-on-dark-subtle font-mono text-[0.625rem] tracking-[0.16em] uppercase">
-						{siteConfig.hours}
+						{contactInfo.hours}
 					</p>
 				</div>
 			</div>

--- a/components/content-hero.tsx
+++ b/components/content-hero.tsx
@@ -3,8 +3,10 @@ import Image from "next/image"
 import Link from "next/link"
 import { ChevronRight, Phone } from "@/components/icons"
 
+import { CallButton } from "@/components/call-button"
+import { ProtectedContactLink } from "@/components/protected-contact"
 import { buttonVariants } from "@/components/ui/button"
-import { siteConfig } from "@/lib/site"
+import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
 
 export type HeroBreadcrumb = {
@@ -169,16 +171,12 @@ export function ContentHero({
 				  Quote there and keeps the big Call button from sm up.
 				*/}
 				<div className="mt-8 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center">
-					<a
-						className={cn(
-							buttonVariants({ size: "xl" }),
-							"hidden w-full sm:inline-flex sm:w-auto",
-						)}
-						href={siteConfig.phoneHref}
-					>
-						<Phone aria-hidden="true" />
-						Call {siteConfig.phone}
-					</a>
+					<CallButton
+						className="hidden w-full sm:inline-flex sm:w-auto"
+						desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+						prefer="dial"
+						size="xl"
+					/>
 					<Link
 						className={cn(
 							buttonVariants({ size: "xl" }),
@@ -199,13 +197,13 @@ export function ContentHero({
 					>
 						Get a Free Quote
 					</Link>
-					<a
+					<ProtectedContactLink
 						className="text-on-dark-muted hover:text-primary-bright inline-flex items-center justify-center gap-2 text-sm font-bold transition-colors sm:hidden"
-						href={siteConfig.phoneHref}
+						kind="vcard"
 					>
-						<Phone className="size-4" aria-hidden="true" />
-						Or call {siteConfig.phone}
-					</a>
+						<Phone aria-hidden="true" className="size-4" />
+						Save our contact
+					</ProtectedContactLink>
 				</div>
 			</div>
 		</section>

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -118,9 +118,17 @@ export function ContentPage({
 			/>
 
 			{document.slug === "contact" ? (
-				<div className="container-shell section-y-tight">
+				<section className="container-shell section-y-tight">
+					<div className="section-head mb-6 max-w-2xl">
+						<p className="spec-label">Start here</p>
+						<h2 className="type-title">Save our contact, then reach out</h2>
+						<p className="type-lead">
+							Add Wade&apos;s to your phone with one tap. After you save, you
+							can call or email from the same card.
+						</p>
+					</div>
 					<VirtualBusinessCard id="contact-business-card" />
-				</div>
+				</section>
 			) : null}
 
 			{marketing ? (

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -13,8 +13,6 @@ import {
 	serviceAreaJsonLd,
 	webPageJsonLd,
 } from "@/lib/seo"
-import { siteConfig } from "@/lib/site"
-
 import { ContentConversionCta } from "@/components/content-conversion-cta"
 import { ContentGallery } from "@/components/content-gallery"
 import { ContentHero } from "@/components/content-hero"
@@ -24,6 +22,7 @@ import { MarkdownContent } from "@/components/markdown-content"
 import { PageViewTracker } from "@/components/page-view-tracker"
 import { PageViewsStat } from "@/components/page-views-stat"
 import { RelatedContentSectionsWithStats } from "@/components/related-content-with-stats"
+import { VirtualBusinessCard } from "@/components/virtual-business-card"
 
 export function ContentPage({
 	document,
@@ -118,6 +117,12 @@ export function ContentPage({
 				variant={marketing ? "marketing" : "default"}
 			/>
 
+			{document.slug === "contact" ? (
+				<div className="container-shell section-y-tight">
+					<VirtualBusinessCard id="contact-business-card" />
+				</div>
+			) : null}
+
 			{marketing ? (
 				<>
 					{document.gallery?.length ? (
@@ -144,13 +149,11 @@ export function ContentPage({
 			<ContentConversionCta
 				conversion={document.conversion}
 				secondaryAction={
-					document.slug === "contact" || document.slug.startsWith("careers")
-						? {
-								href: `mailto:${siteConfig.email}`,
-								label: "Email Us",
-								external: true,
-							}
-						: undefined
+					document.slug === "contact"
+						? { label: "Email Us", contact: "email" }
+						: document.slug.startsWith("careers")
+							? { label: "Email Us", contact: "email" }
+							: undefined
 				}
 			/>
 			<JsonLd data={jsonLd} />

--- a/components/glossary-term-page.tsx
+++ b/components/glossary-term-page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link"
 
 import { ContentHero } from "@/components/content-hero"
 import { JsonLd } from "@/components/json-ld"
+import { ProtectedPhoneText } from "@/components/protected-contact"
 import {
 	glossaryHubPath,
 	glossaryTermPath,
@@ -13,8 +14,6 @@ import {
 	breadcrumbJsonLd,
 	definedTermJsonLd,
 } from "@/lib/seo"
-import { siteConfig } from "@/lib/site"
-
 function paragraphs(text: string) {
 	return text
 		.split(/\n\n+/)
@@ -154,12 +153,7 @@ export function GlossaryTermPage({
 							: "Septic Glossary"}
 					</Link>{" "}
 					or call{" "}
-					<a
-						className="text-primary font-bold underline-offset-2 hover:underline"
-						href={siteConfig.phoneHref}
-					>
-						{siteConfig.phone}
-					</a>{" "}
+					<ProtectedPhoneText className="text-primary font-bold underline-offset-2 hover:underline" />{" "}
 					with questions about your property.
 				</p>
 			</article>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -23,6 +23,7 @@ import {
 	Gauge as PhGauge,
 	Hash as PhHash,
 	House,
+	IdentificationCard as PhIdentificationCard,
 	List,
 	MagnifyingGlass,
 	MapPin as PhMapPin,
@@ -77,6 +78,10 @@ export const Eye = duotone(PhEye, "Eye")
 export const FileText = duotone(PhFileText, "FileText")
 export const Gauge = duotone(PhGauge, "Gauge")
 export const Hash = duotone(PhHash, "Hash")
+export const IdentificationCard = duotone(
+	PhIdentificationCard,
+	"IdentificationCard",
+)
 export const MapPin = duotone(PhMapPin, "MapPin")
 export const Minus = duotone(PhMinus, "Minus")
 export const Phone = duotone(PhPhone, "Phone")

--- a/components/markdown-content.tsx
+++ b/components/markdown-content.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
 
+import { ProtectedContactLink } from "@/components/protected-contact"
 import { cn } from "@/lib/utils"
 
 function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
@@ -64,6 +65,24 @@ export function MarkdownContent({
 								<Link href={href as Route} prefetch={false} {...props}>
 									{children}
 								</Link>
+							)
+						}
+
+						// Keep visible link text; apply real tel:/mailto: only on the client
+						// so scrapers do not harvest contiguous contact hrefs from HTML.
+						if (href.startsWith("tel:")) {
+							return (
+								<ProtectedContactLink kind="phone" {...props}>
+									{children}
+								</ProtectedContactLink>
+							)
+						}
+
+						if (href.startsWith("mailto:")) {
+							return (
+								<ProtectedContactLink kind="email" {...props}>
+									{children}
+								</ProtectedContactLink>
 							)
 						}
 

--- a/components/protected-contact.tsx
+++ b/components/protected-contact.tsx
@@ -1,0 +1,121 @@
+"use client"
+
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type ComponentPropsWithoutRef,
+	type ReactNode,
+} from "react"
+
+import {
+	contactEncoded,
+	contactInfo,
+	decodeContactValue,
+} from "@/lib/contact"
+import { cn } from "@/lib/utils"
+
+const useIsomorphicLayoutEffect =
+	typeof window !== "undefined" ? useLayoutEffect : useEffect
+
+type ContactKind = "phone" | "email" | "vcard"
+
+function payloadFor(kind: ContactKind) {
+	switch (kind) {
+		case "phone":
+			return {
+				href: contactEncoded.phoneHref,
+				label: contactEncoded.phoneDisplay,
+				fallbackHref: "#call-wades",
+				fallbackLabel: contactInfo.phoneDisplay,
+			}
+		case "email":
+			return {
+				href: contactEncoded.emailHref,
+				label: contactEncoded.email,
+				fallbackHref: "#email-wades",
+				fallbackLabel: contactInfo.email,
+			}
+		case "vcard":
+			return {
+				href: contactEncoded.vcardPath,
+				label: contactEncoded.phoneDisplay,
+				fallbackHref: contactInfo.vcardPath,
+				fallbackLabel: "Save contact",
+			}
+	}
+}
+
+/**
+ * Renders a visible phone/email/vCard link without putting a harvestable
+ * tel: or mailto: href in the server HTML. The real href is applied on the
+ * client before paint when possible.
+ */
+export function ProtectedContactLink({
+	kind,
+	className,
+	children,
+	ariaLabel,
+	...rest
+}: {
+	kind: ContactKind
+	className?: string
+	children?: ReactNode
+	ariaLabel?: string
+} & Omit<ComponentPropsWithoutRef<"a">, "href" | "children" | "className">) {
+	const payload = payloadFor(kind)
+	const ref = useRef<HTMLAnchorElement>(null)
+	const [label, setLabel] = useState(payload.fallbackLabel)
+
+	useIsomorphicLayoutEffect(() => {
+		const href = decodeContactValue(payload.href)
+		const text = decodeContactValue(payload.label)
+		const node = ref.current
+		if (node) node.href = href
+		if (!children) setLabel(text)
+	}, [payload.href, payload.label, children])
+
+	return (
+		<a
+			ref={ref}
+			aria-label={ariaLabel}
+			className={cn(className)}
+			href={payload.fallbackHref}
+			suppressHydrationWarning
+			{...rest}
+		>
+			{children ?? label}
+		</a>
+	)
+}
+
+/** Visible phone number text with a dial link applied after hydration. */
+export function ProtectedPhoneText({
+	className,
+}: {
+	className?: string
+}) {
+	return (
+		<ProtectedContactLink
+			ariaLabel={`Call ${contactInfo.phoneDisplay}`}
+			className={className}
+			kind="phone"
+		/>
+	)
+}
+
+/** Visible email with a mailto link applied after hydration. */
+export function ProtectedEmailText({
+	className,
+}: {
+	className?: string
+}) {
+	return (
+		<ProtectedContactLink
+			ariaLabel={`Email ${contactInfo.email}`}
+			className={className}
+			kind="email"
+		/>
+	)
+}

--- a/components/save-contact-button.tsx
+++ b/components/save-contact-button.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useEffect, useRef, useState, type ReactNode } from "react"
+import { IdentificationCard, Phone } from "@/components/icons"
+
+import { ProtectedContactLink } from "@/components/protected-contact"
+import { buttonVariants } from "@/components/ui/button"
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetFooter,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet"
+import { contactInfo } from "@/lib/contact"
+import { cn } from "@/lib/utils"
+
+/**
+ * Opens the vCard, then offers a Call action when the user comes back
+ * (visibility/focus) or after a short delay if the OS never backgrounds the tab.
+ * Browsers cannot detect a completed contact save, so this is a best-effort nudge.
+ */
+export function SaveContactButton({
+	className,
+	children = "Save to phone",
+	variant = "default",
+	size = "lg",
+	showIcon = true,
+}: {
+	className?: string
+	children?: ReactNode
+	variant?: "default" | "secondary" | "inverse" | "outline" | "ghost"
+	size?: "default" | "sm" | "lg" | "xl" | "icon"
+	showIcon?: boolean
+}) {
+	const [promptOpen, setPromptOpen] = useState(false)
+	const awaitingReturn = useRef(false)
+	const fallbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+	useEffect(() => {
+		function maybePrompt() {
+			if (!awaitingReturn.current) return
+			awaitingReturn.current = false
+			if (fallbackTimer.current) {
+				clearTimeout(fallbackTimer.current)
+				fallbackTimer.current = null
+			}
+			setPromptOpen(true)
+		}
+
+		function onVisibility() {
+			if (document.visibilityState === "visible") maybePrompt()
+		}
+
+		window.addEventListener("focus", maybePrompt)
+		document.addEventListener("visibilitychange", onVisibility)
+		return () => {
+			window.removeEventListener("focus", maybePrompt)
+			document.removeEventListener("visibilitychange", onVisibility)
+			if (fallbackTimer.current) clearTimeout(fallbackTimer.current)
+		}
+	}, [])
+
+	function armPrompt() {
+		awaitingReturn.current = true
+		if (fallbackTimer.current) clearTimeout(fallbackTimer.current)
+		// Some devices download/open the vCard without leaving the page.
+		fallbackTimer.current = setTimeout(() => {
+			if (!awaitingReturn.current) return
+			awaitingReturn.current = false
+			setPromptOpen(true)
+		}, 2200)
+	}
+
+	return (
+		<>
+			<ProtectedContactLink
+				ariaLabel="Save Wade's Plumbing & Septic to your contacts"
+				className={cn(buttonVariants({ size, variant }), className)}
+				kind="vcard"
+				onClick={armPrompt}
+			>
+				{showIcon ? <IdentificationCard aria-hidden="true" /> : null}
+				{children}
+			</ProtectedContactLink>
+
+			<Sheet open={promptOpen} onOpenChange={setPromptOpen}>
+				<SheetContent
+					className="bg-card gap-0 rounded-t-2xl sm:mx-auto sm:max-w-md sm:rounded-t-2xl"
+					side="bottom"
+				>
+					<SheetHeader className="pb-2">
+						<SheetTitle>Ready to call?</SheetTitle>
+						<SheetDescription>
+							If you saved Wade&apos;s to your contacts, you can dial us next.
+							We are here {contactInfo.hours.toLowerCase()}.
+						</SheetDescription>
+					</SheetHeader>
+					<SheetFooter className="pb-[max(1.25rem,env(safe-area-inset-bottom))]">
+						<ProtectedContactLink
+							ariaLabel={`Call ${contactInfo.phoneDisplay}`}
+							className={cn(buttonVariants({ size: "xl" }), "w-full")}
+							kind="phone"
+							onClick={() => setPromptOpen(false)}
+						>
+							<Phone aria-hidden="true" />
+							Call {contactInfo.phoneDisplay}
+						</ProtectedContactLink>
+						<button
+							className={cn(
+								buttonVariants({ variant: "ghost", size: "lg" }),
+								"w-full",
+							)}
+							onClick={() => setPromptOpen(false)}
+							type="button"
+						>
+							Not now
+						</button>
+					</SheetFooter>
+				</SheetContent>
+			</Sheet>
+		</>
+	)
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,12 +1,12 @@
 import type { Route } from "next"
 import Image from "next/image"
 import Link from "next/link"
-import { Phone } from "@/components/icons"
 
+import { CallButton } from "@/components/call-button"
 import { CompanyLogo } from "@/components/company-logos"
-import { buttonVariants } from "@/components/ui/button"
+import { ProtectedPhoneText } from "@/components/protected-contact"
+import { VirtualBusinessCard } from "@/components/virtual-business-card"
 import { companyNavigation, resourceNavigation, siteConfig } from "@/lib/site"
-import { cn } from "@/lib/utils"
 
 const serviceLinks = [
 	{ href: "/service-offerings/drain-cleaning", label: "Drain Cleaning" },
@@ -40,7 +40,7 @@ export function SiteFooter() {
 							{siteConfig.hours}
 						</p>
 						<p className="type-subtitle mt-1 text-white">
-							{siteConfig.phone}
+							<ProtectedPhoneText className="text-inherit hover:text-white" />
 						</p>
 					</div>
 					{/*
@@ -48,27 +48,28 @@ export function SiteFooter() {
 					  text-foreground, which in dark mode resolves to near-white - an
 					  invisible label on a white button.
 					*/}
-					<a
-						className={cn(
-							buttonVariants({ variant: "secondary", size: "lg" }),
-							"text-ink w-full bg-white hover:bg-white/90 sm:w-auto",
-						)}
-						href={siteConfig.phoneHref}
-					>
-						<Phone aria-hidden="true" />
-						Call now
-					</a>
+					<CallButton
+						className="text-ink w-full bg-white hover:bg-white/90 sm:w-auto"
+						desktopLabel="Call now"
+						mobileLabel="Save contact"
+						size="lg"
+						variant="secondary"
+					/>
 				</div>
 			</div>
 
 			<div className="container-shell py-[var(--space-section-y-tight)]">
+				<div className="mb-[var(--space-block)]">
+					<VirtualBusinessCard id="footer-business-card" tone="dark" />
+				</div>
+
 				<div className="grid gap-[var(--space-block)] sm:grid-cols-2 lg:grid-cols-[minmax(0,1.4fr)_repeat(3,minmax(0,1fr))]">
 					<div>
 						<Link
+							aria-label="Wade's Plumbing & Septic home"
 							className="flex items-center gap-3"
 							href="/"
 							prefetch
-							aria-label="Wade's Plumbing & Septic home"
 						>
 							<Image
 								alt="Wade's Plumbing & Septic logo"
@@ -99,9 +100,9 @@ export function SiteFooter() {
 						<div className="mt-6 flex gap-2">
 							{socialLinks.map((item) => (
 								<a
+									aria-label={item.label}
 									className="focus-visible:ring-ring grid size-10 place-items-center rounded-md bg-white/8 opacity-80 transition-opacity outline-none hover:opacity-100 focus-visible:ring-2"
 									href={item.href}
-									aria-label={item.label}
 									key={item.label}
 									rel="noopener noreferrer"
 									target="_blank"
@@ -112,9 +113,9 @@ export function SiteFooter() {
 						</div>
 					</div>
 
-					<FooterColumn title="Services" links={serviceLinks} />
-					<FooterColumn title="Company" links={companyNavigation} />
-					<FooterColumn title="Resources" links={resourceNavigation} />
+					<FooterColumn links={serviceLinks} title="Services" />
+					<FooterColumn links={companyNavigation} title="Company" />
+					<FooterColumn links={resourceNavigation} title="Resources" />
 				</div>
 
 				<div className="text-on-dark-subtle mt-[var(--space-block)] flex flex-col gap-4 border-t border-white/10 pt-7 text-xs sm:flex-row sm:items-center sm:justify-between">

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -51,7 +51,7 @@ export function SiteFooter() {
 					<CallButton
 						className="text-ink w-full bg-white hover:bg-white/90 sm:w-auto"
 						desktopLabel="Call now"
-						mobileLabel="Save contact"
+						prefer="dial"
 						size="lg"
 						variant="secondary"
 					/>
@@ -60,6 +60,13 @@ export function SiteFooter() {
 
 			<div className="container-shell py-[var(--space-section-y-tight)]">
 				<div className="mb-[var(--space-block)]">
+					<p className="text-primary-bright mb-3 font-mono text-[0.6875rem] font-semibold tracking-[0.14em] uppercase">
+						Keep us handy
+					</p>
+					<p className="text-on-dark-muted mb-5 max-w-xl text-sm leading-relaxed">
+						Save Wade&apos;s to your phone, then call or text whenever you need
+						plumbing or septic help.
+					</p>
 					<VirtualBusinessCard id="footer-business-card" tone="dark" />
 				</div>
 

--- a/components/site-header-mobile-menu.tsx
+++ b/components/site-header-mobile-menu.tsx
@@ -6,8 +6,10 @@ import Link from "next/link"
 import { useRouter } from "next/navigation"
 import type { ReactNode } from "react"
 
-import { ArrowRight, Phone } from "@/components/icons"
+import { ArrowRight } from "@/components/icons"
+import { CallButton } from "@/components/call-button"
 import { buttonVariants } from "@/components/ui/button"
+import { contactInfo } from "@/lib/contact"
 import { Separator } from "@/components/ui/separator"
 import {
 	Sheet,
@@ -223,13 +225,12 @@ export function SiteHeaderMobileMenu({
 				</nav>
 
 				<SheetFooter className="shrink-0 gap-2">
-					<a
-						className={cn(buttonVariants({ size: "lg" }), "w-full gap-2")}
-						href={siteConfig.phoneHref}
-					>
-						<Phone aria-hidden="true" />
-						Call {siteConfig.phone}
-					</a>
+					<CallButton
+						className="w-full gap-2"
+						desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+						mobileLabel="Save contact"
+						size="lg"
+					/>
 					<button
 						type="button"
 						className={cn(

--- a/components/site-header-nav.tsx
+++ b/components/site-header-nav.tsx
@@ -24,7 +24,9 @@ import {
 	type IconComponent,
 } from "@/components/icons"
 
+import { CallButton, CallIconButton } from "@/components/call-button"
 import { Button, buttonVariants } from "@/components/ui/button"
+import { contactInfo } from "@/lib/contact"
 import { openGlobalSearch } from "@/lib/search-events"
 import { prefetchSearchIndex } from "@/lib/search-client"
 import {
@@ -124,13 +126,11 @@ function MegaFooter({
 				<span>{siteConfig.hours}</span>
 			</p>
 			<div className="flex shrink-0 items-center gap-2">
-				<a
-					className={buttonVariants({ size: "sm" })}
-					href={siteConfig.phoneHref}
-				>
-					<Phone aria-hidden="true" />
-					{siteConfig.phone}
-				</a>
+				<CallButton
+					desktopLabel={contactInfo.phoneDisplay}
+					prefer="dial"
+					size="sm"
+				/>
 				<NavigationMenuLink asChild>
 					<Link
 						className={buttonVariants({ variant: "inverse", size: "sm" })}
@@ -324,12 +324,12 @@ export function SiteHeaderNav() {
 				>
 					<Search aria-hidden="true" className="size-5" />
 				</Button>
-				<Button asChild size="lg">
-					<a className="gap-2" href={siteConfig.phoneHref}>
-						<Phone aria-hidden="true" />
-						{siteConfig.phone}
-					</a>
-				</Button>
+				<CallButton
+					className="gap-2"
+					desktopLabel={contactInfo.phoneDisplay}
+					prefer="dial"
+					size="lg"
+				/>
 			</div>
 
 			<div className="flex items-center lg:hidden">
@@ -345,19 +345,7 @@ export function SiteHeaderNav() {
 				>
 					<Search aria-hidden="true" className="size-5" />
 				</Button>
-				<Button
-					asChild
-					variant="ghost"
-					size="icon"
-					className="hover:text-primary-bright focus-visible:ring-offset-ink text-white hover:bg-transparent sm:hidden"
-				>
-					<a
-						href={siteConfig.phoneHref}
-						aria-label={`Call ${siteConfig.phone}`}
-					>
-						<Phone aria-hidden="true" className="size-5" />
-					</a>
-				</Button>
+				<CallIconButton className="hover:text-primary-bright focus-visible:ring-offset-ink inline-flex size-11 items-center justify-center rounded-md text-white hover:bg-transparent sm:hidden" />
 				<Button
 					type="button"
 					variant="ghost"

--- a/components/virtual-business-card.tsx
+++ b/components/virtual-business-card.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image"
-import { Clock, IdentificationCard, Mail, MapPin, Phone } from "@/components/icons"
+import { Mail } from "@/components/icons"
 
 import { CallButton } from "@/components/call-button"
 import {
@@ -7,14 +7,15 @@ import {
 	ProtectedEmailText,
 	ProtectedPhoneText,
 } from "@/components/protected-contact"
+import { SaveContactButton } from "@/components/save-contact-button"
 import { buttonVariants } from "@/components/ui/button"
 import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
 
 /**
- * Virtual business card: logo, hours, protected phone/email, address, and
- * actions to save the vCard or dial/email. Safe to place on light or dark bands
- * via the `tone` prop.
+ * Virtual business card: one clean contact composition with save + call.
+ * Mobile keeps a single vertical flow (no icon-tile grid). Desktop adds a
+ * side action column.
  */
 export function VirtualBusinessCard({
 	tone = "light",
@@ -31,24 +32,20 @@ export function VirtualBusinessCard({
 		<section
 			aria-labelledby={`${id}-title`}
 			className={cn(
-				"overflow-hidden rounded-xl",
+				"overflow-hidden",
 				dark
-					? "surface-float"
-					: "border-border bg-card shadow-[var(--shadow-panel)] border",
+					? "rounded-xl border border-white/10 bg-white/[0.04]"
+					: "border-border bg-card shadow-[var(--shadow-panel)] rounded-xl border",
 				className,
 			)}
 			id={id}
 		>
-			<div
-				className={cn(
-					"flex flex-col gap-6 p-[var(--space-card)] sm:flex-row sm:items-stretch sm:gap-8 sm:p-7",
-				)}
-			>
-				<div className="flex min-w-0 flex-1 flex-col gap-5">
-					<div className="flex items-start gap-3">
+			<div className="flex flex-col sm:flex-row sm:items-stretch">
+				<div className="flex min-w-0 flex-1 flex-col gap-5 p-5 sm:gap-6 sm:p-7">
+					<div className="flex items-center gap-3.5">
 						<Image
 							alt="Wade's Plumbing & Septic logo"
-							className="size-14 shrink-0 rounded-md"
+							className="size-12 shrink-0 rounded-md sm:size-14"
 							height={56}
 							src="/images/brand/wades-mark-sm.webp"
 							width={56}
@@ -56,16 +53,16 @@ export function VirtualBusinessCard({
 						<div className="min-w-0">
 							<p
 								className={cn(
-									"spec-label",
-									dark ? "text-primary-bright" : undefined,
+									"font-mono text-[0.6875rem] font-semibold tracking-[0.14em] uppercase",
+									dark ? "text-primary-bright" : "text-primary",
 								)}
 							>
 								Virtual business card
 							</p>
 							<h2
 								className={cn(
-									"type-subtitle mt-2 text-[1.25rem]",
-									dark ? "text-white" : undefined,
+									"font-display mt-1 text-[1.2rem] leading-tight font-extrabold tracking-[-0.02em] sm:text-[1.35rem]",
+									dark ? "text-white" : "text-foreground",
 								)}
 								id={`${id}-title`}
 							>
@@ -74,52 +71,35 @@ export function VirtualBusinessCard({
 						</div>
 					</div>
 
-					<ul className="grid gap-3 text-sm">
-						<li className="flex items-start gap-3">
-							<span
+					<div
+						className={cn(
+							"grid gap-4 border-y py-4",
+							dark ? "border-white/10" : "border-border",
+						)}
+					>
+						<div>
+							<p
 								className={cn(
-									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
-									dark
-										? "bg-white/10 text-primary-bright"
-										: "bg-accent text-accent-foreground",
+									"font-mono text-[0.625rem] tracking-[0.14em] uppercase",
+									dark ? "text-on-dark-subtle" : "text-muted-foreground",
 								)}
 							>
-								<Phone aria-hidden="true" className="size-4" />
-							</span>
+								Phone
+							</p>
+							<ProtectedPhoneText
+								className={cn(
+									"mt-1 text-xl font-extrabold tracking-[-0.02em] transition-colors sm:text-2xl",
+									dark
+										? "text-white hover:text-primary-bright"
+										: "text-foreground hover:text-primary",
+								)}
+							/>
+						</div>
+						<div className="grid gap-3 sm:grid-cols-2 sm:gap-6">
 							<div className="min-w-0">
 								<p
 									className={cn(
-										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
-										dark ? "text-on-dark-subtle" : "text-muted-foreground",
-									)}
-								>
-									Call or text
-								</p>
-								<ProtectedPhoneText
-									className={cn(
-										"mt-0.5 text-base font-bold transition-colors",
-										dark
-											? "text-white hover:text-primary-bright"
-											: "text-foreground hover:text-primary",
-									)}
-								/>
-							</div>
-						</li>
-						<li className="flex items-start gap-3">
-							<span
-								className={cn(
-									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
-									dark
-										? "bg-white/10 text-primary-bright"
-										: "bg-accent text-accent-foreground",
-								)}
-							>
-								<Mail aria-hidden="true" className="size-4" />
-							</span>
-							<div className="min-w-0">
-								<p
-									className={cn(
-										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										"font-mono text-[0.625rem] tracking-[0.14em] uppercase",
 										dark ? "text-on-dark-subtle" : "text-muted-foreground",
 									)}
 								>
@@ -127,80 +107,72 @@ export function VirtualBusinessCard({
 								</p>
 								<ProtectedEmailText
 									className={cn(
-										"mt-0.5 break-all text-base font-bold transition-colors",
+										"mt-1 block text-sm font-bold break-all transition-colors sm:text-base",
 										dark
 											? "text-white hover:text-primary-bright"
 											: "text-foreground hover:text-primary",
 									)}
 								/>
 							</div>
-						</li>
-						<li className="flex items-start gap-3">
-							<span
-								className={cn(
-									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
-									dark
-										? "bg-white/10 text-primary-bright"
-										: "bg-accent text-accent-foreground",
-								)}
-							>
-								<MapPin aria-hidden="true" className="size-4" />
-							</span>
 							<div className="min-w-0">
 								<p
 									className={cn(
-										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										"font-mono text-[0.625rem] tracking-[0.14em] uppercase",
 										dark ? "text-on-dark-subtle" : "text-muted-foreground",
 									)}
 								>
-									Office
+									Office & hours
 								</p>
 								<p
 									className={cn(
-										"mt-0.5 text-base font-bold leading-snug",
+										"mt-1 text-sm leading-snug font-bold sm:text-base",
 										dark ? "text-white" : "text-foreground",
 									)}
 								>
 									{contactInfo.address.display}
 								</p>
-							</div>
-						</li>
-						<li className="flex items-start gap-3">
-							<span
-								className={cn(
-									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
-									dark
-										? "bg-white/10 text-primary-bright"
-										: "bg-accent text-accent-foreground",
-								)}
-							>
-								<Clock aria-hidden="true" className="size-4" />
-							</span>
-							<div className="min-w-0">
 								<p
 									className={cn(
-										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
-										dark ? "text-on-dark-subtle" : "text-muted-foreground",
-									)}
-								>
-									Hours
-								</p>
-								<p
-									className={cn(
-										"mt-0.5 text-base font-bold",
-										dark ? "text-white" : "text-foreground",
+										"mt-1 text-sm",
+										dark ? "text-on-dark-muted" : "text-muted-foreground",
 									)}
 								>
 									{contactInfo.hours}
 								</p>
 							</div>
-						</li>
-					</ul>
+						</div>
+					</div>
+
+					{/* Mobile actions live in the main flow so the card reads as one unit. */}
+					<div className="grid gap-2 sm:hidden">
+						<SaveContactButton className="w-full" size="lg" />
+						<CallButton
+							className="w-full"
+							desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+							prefer="dial"
+							size="lg"
+							variant={dark ? "inverse" : "outline"}
+						/>
+						<ProtectedContactLink
+							ariaLabel={`Email ${contactInfo.email}`}
+							className={cn(
+								buttonVariants({ variant: "ghost", size: "lg" }),
+								"w-full",
+								dark
+									? "text-on-dark-muted hover:text-white"
+									: "text-muted-foreground",
+							)}
+							kind="email"
+						>
+							<Mail aria-hidden="true" />
+							Email us
+						</ProtectedContactLink>
+					</div>
 				</div>
 
 				<div
 					className={cn(
-						"flex shrink-0 flex-col justify-center gap-3 border-t pt-5 sm:w-56 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-8",
+						"hidden shrink-0 flex-col justify-center gap-3 border-t p-5 sm:flex sm:w-60 sm:border-t-0 sm:border-l sm:p-7",
 						dark ? "border-white/10" : "border-border",
 					)}
 				>
@@ -210,17 +182,10 @@ export function VirtualBusinessCard({
 							dark ? "text-on-dark-muted" : "text-muted-foreground",
 						)}
 					>
-						On a phone, save our card to your contacts with the logo, number,
-						email, and address ready to use.
+						Save our card to your phone with the logo, number, email, and
+						address ready. After you save, you can call right away.
 					</p>
-					<ProtectedContactLink
-						ariaLabel="Save Wade's Plumbing & Septic to your contacts"
-						className={cn(buttonVariants({ size: "lg" }), "w-full")}
-						kind="vcard"
-					>
-						<IdentificationCard aria-hidden="true" />
-						Save to phone
-					</ProtectedContactLink>
+					<SaveContactButton className="w-full" size="lg" />
 					<CallButton
 						className="w-full"
 						desktopLabel={`Call ${contactInfo.phoneDisplay}`}

--- a/components/virtual-business-card.tsx
+++ b/components/virtual-business-card.tsx
@@ -1,0 +1,249 @@
+import Image from "next/image"
+import { Clock, IdentificationCard, Mail, MapPin, Phone } from "@/components/icons"
+
+import { CallButton } from "@/components/call-button"
+import {
+	ProtectedContactLink,
+	ProtectedEmailText,
+	ProtectedPhoneText,
+} from "@/components/protected-contact"
+import { buttonVariants } from "@/components/ui/button"
+import { contactInfo } from "@/lib/contact"
+import { cn } from "@/lib/utils"
+
+/**
+ * Virtual business card: logo, hours, protected phone/email, address, and
+ * actions to save the vCard or dial/email. Safe to place on light or dark bands
+ * via the `tone` prop.
+ */
+export function VirtualBusinessCard({
+	tone = "light",
+	className,
+	id = "virtual-business-card",
+}: {
+	tone?: "light" | "dark"
+	className?: string
+	id?: string
+}) {
+	const dark = tone === "dark"
+
+	return (
+		<section
+			aria-labelledby={`${id}-title`}
+			className={cn(
+				"overflow-hidden rounded-xl",
+				dark
+					? "surface-float"
+					: "border-border bg-card shadow-[var(--shadow-panel)] border",
+				className,
+			)}
+			id={id}
+		>
+			<div
+				className={cn(
+					"flex flex-col gap-6 p-[var(--space-card)] sm:flex-row sm:items-stretch sm:gap-8 sm:p-7",
+				)}
+			>
+				<div className="flex min-w-0 flex-1 flex-col gap-5">
+					<div className="flex items-start gap-3">
+						<Image
+							alt="Wade's Plumbing & Septic logo"
+							className="size-14 shrink-0 rounded-md"
+							height={56}
+							src="/images/brand/wades-mark-sm.webp"
+							width={56}
+						/>
+						<div className="min-w-0">
+							<p
+								className={cn(
+									"spec-label",
+									dark ? "text-primary-bright" : undefined,
+								)}
+							>
+								Virtual business card
+							</p>
+							<h2
+								className={cn(
+									"type-subtitle mt-2 text-[1.25rem]",
+									dark ? "text-white" : undefined,
+								)}
+								id={`${id}-title`}
+							>
+								{contactInfo.displayName}
+							</h2>
+						</div>
+					</div>
+
+					<ul className="grid gap-3 text-sm">
+						<li className="flex items-start gap-3">
+							<span
+								className={cn(
+									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
+									dark
+										? "bg-white/10 text-primary-bright"
+										: "bg-accent text-accent-foreground",
+								)}
+							>
+								<Phone aria-hidden="true" className="size-4" />
+							</span>
+							<div className="min-w-0">
+								<p
+									className={cn(
+										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										dark ? "text-on-dark-subtle" : "text-muted-foreground",
+									)}
+								>
+									Call or text
+								</p>
+								<ProtectedPhoneText
+									className={cn(
+										"mt-0.5 text-base font-bold transition-colors",
+										dark
+											? "text-white hover:text-primary-bright"
+											: "text-foreground hover:text-primary",
+									)}
+								/>
+							</div>
+						</li>
+						<li className="flex items-start gap-3">
+							<span
+								className={cn(
+									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
+									dark
+										? "bg-white/10 text-primary-bright"
+										: "bg-accent text-accent-foreground",
+								)}
+							>
+								<Mail aria-hidden="true" className="size-4" />
+							</span>
+							<div className="min-w-0">
+								<p
+									className={cn(
+										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										dark ? "text-on-dark-subtle" : "text-muted-foreground",
+									)}
+								>
+									Email
+								</p>
+								<ProtectedEmailText
+									className={cn(
+										"mt-0.5 break-all text-base font-bold transition-colors",
+										dark
+											? "text-white hover:text-primary-bright"
+											: "text-foreground hover:text-primary",
+									)}
+								/>
+							</div>
+						</li>
+						<li className="flex items-start gap-3">
+							<span
+								className={cn(
+									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
+									dark
+										? "bg-white/10 text-primary-bright"
+										: "bg-accent text-accent-foreground",
+								)}
+							>
+								<MapPin aria-hidden="true" className="size-4" />
+							</span>
+							<div className="min-w-0">
+								<p
+									className={cn(
+										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										dark ? "text-on-dark-subtle" : "text-muted-foreground",
+									)}
+								>
+									Office
+								</p>
+								<p
+									className={cn(
+										"mt-0.5 text-base font-bold leading-snug",
+										dark ? "text-white" : "text-foreground",
+									)}
+								>
+									{contactInfo.address.display}
+								</p>
+							</div>
+						</li>
+						<li className="flex items-start gap-3">
+							<span
+								className={cn(
+									"mt-0.5 grid size-8 shrink-0 place-items-center rounded-md",
+									dark
+										? "bg-white/10 text-primary-bright"
+										: "bg-accent text-accent-foreground",
+								)}
+							>
+								<Clock aria-hidden="true" className="size-4" />
+							</span>
+							<div className="min-w-0">
+								<p
+									className={cn(
+										"font-mono text-[0.6875rem] tracking-[0.12em] uppercase",
+										dark ? "text-on-dark-subtle" : "text-muted-foreground",
+									)}
+								>
+									Hours
+								</p>
+								<p
+									className={cn(
+										"mt-0.5 text-base font-bold",
+										dark ? "text-white" : "text-foreground",
+									)}
+								>
+									{contactInfo.hours}
+								</p>
+							</div>
+						</li>
+					</ul>
+				</div>
+
+				<div
+					className={cn(
+						"flex shrink-0 flex-col justify-center gap-3 border-t pt-5 sm:w-56 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-8",
+						dark ? "border-white/10" : "border-border",
+					)}
+				>
+					<p
+						className={cn(
+							"text-sm leading-relaxed",
+							dark ? "text-on-dark-muted" : "text-muted-foreground",
+						)}
+					>
+						On a phone, save our card to your contacts with the logo, number,
+						email, and address ready to use.
+					</p>
+					<ProtectedContactLink
+						ariaLabel="Save Wade's Plumbing & Septic to your contacts"
+						className={cn(buttonVariants({ size: "lg" }), "w-full")}
+						kind="vcard"
+					>
+						<IdentificationCard aria-hidden="true" />
+						Save to phone
+					</ProtectedContactLink>
+					<CallButton
+						className="w-full"
+						desktopLabel={`Call ${contactInfo.phoneDisplay}`}
+						prefer="dial"
+						size="lg"
+						variant={dark ? "inverse" : "outline"}
+					/>
+					<ProtectedContactLink
+						ariaLabel={`Email ${contactInfo.email}`}
+						className={cn(
+							buttonVariants({ variant: "ghost", size: "lg" }),
+							"w-full",
+							dark
+								? "text-on-dark-muted hover:text-white"
+								: "text-muted-foreground",
+						)}
+						kind="email"
+					>
+						<Mail aria-hidden="true" />
+						Email us
+					</ProtectedContactLink>
+				</div>
+			</div>
+		</section>
+	)
+}

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -12,13 +12,11 @@ eyebrow: Call or Text 831.225.4344
 
 ## Contact Wade's Plumbing & Septic
 
-Need a plumber or septic tech in Santa Cruz County or nearby foothill communities? Call or text **[831.225.4344](tel:+18312254344)**, email **[support@wadesinc.io](mailto:support@wadesinc.io)**, or use the request options on this page. We confirm your address, triage the issue, and get you on the schedule.
+Need a plumber or septic tech in Santa Cruz County or nearby foothill communities? Use the virtual business card above to save our number, email, address, and logo to your phone, or call and text from there. We confirm your address, triage the issue, and get you on the schedule.
 
 ## Call or text
 
-**[831.225.4344](tel:+18312254344)**
-
-Use this number for scheduling, questions, and urgent plumbing or septic problems. Texting works when you cannot talk. Have ready:
+Use the number on the card for scheduling, questions, and urgent plumbing or septic problems. Texting works when you cannot talk. Have ready:
 
 - City or ZIP for the property
 - Whether the issue is plumbing, septic, or commercial
@@ -30,9 +28,7 @@ For the fastest intake path, see our [call-first checklist](/contact-call-first)
 
 ## Email
 
-**[support@wadesinc.io](mailto:support@wadesinc.io)**
-
-Best for photos, permit questions, and non-urgent follow-up. Include the property address and a short description of what is happening.
+Best for photos, permit questions, and non-urgent follow-up. Include the property address and a short description of what is happening. Tap Email us on the card above when you are ready.
 
 ## Office
 
@@ -47,7 +43,7 @@ We are based in the San Lorenzo Valley and dispatch across Santa Cruz County and
 - **Monday through Friday:** 9:00 AM to 5:00 PM
 - **Saturday and Sunday:** Closed for routine scheduling
 
-Call **[831.225.4344](tel:+18312254344)** during office hours to book service. If you reach us outside those hours, leave a message or text and we will return contact on the next business day.
+Call during office hours to book service. If you reach us outside those hours, leave a message or text and we will return contact on the next business day.
 
 ## Licensing
 
@@ -68,20 +64,16 @@ Tell us what is going on and we will point you to the right next step: inspectio
 
 ### How do I get a quote?
 
-Call or text **831.225.4344** or email **support@wadesinc.io** with the property address and a description of the problem. Many jobs need an on-site look before we can give a firm number. We explain options before work starts.
+Call or text, or email us with the property address and a description of the problem. Many jobs need an on-site look before we can give a firm number. We explain options before work starts.
 
 ### Do you offer emergency plumbing help?
 
-Call **831.225.4344**. During office hours we triage urgent leaks, backups, and septic alarms as quickly as the schedule allows. Outside office hours, leave a message or text with the address and what is happening so we can respond as soon as we are available.
+Call the number on the card. During office hours we triage urgent leaks, backups, and septic alarms as quickly as the schedule allows. Outside office hours, leave a message or text with the address and what is happening so we can respond as soon as we are available.
 
 ### What should I expect on a service visit?
 
 We confirm the address and issue when you book, arrive ready to diagnose, explain what we find in plain language, and complete agreed work with testing and cleanup. You get clear recommendations, not a hard sell.
 
-### How long does a typical job take?
+### Can I save your contact on my phone?
 
-Many drain, fixture, and water heater visits finish the same day. Septic inspections, pumping, and engineered system work depend on site conditions, permits, and parts. We give a realistic timeframe after we understand the job.
-
-### Why choose Wade's?
-
-We are local, family-owned, and licensed for plumbing and onsite wastewater work (CSLB #1087260). We know Santa Cruz County soils, older mountain plumbing, coastal rentals, and county septic expectations. Honest assessment first; then the right fix.
+Yes. Tap Save to phone on the virtual business card. It opens a contact card with our logo, phone, email, address, website, and license notes so you can call us later without hunting for the number.

--- a/lib/contact.ts
+++ b/lib/contact.ts
@@ -1,0 +1,64 @@
+import { siteConfig } from "@/lib/site"
+
+/** Public path that serves the downloadable / openable vCard. */
+export const VCARD_PATH = "/contact.vcf" as const
+
+export const contactInfo = {
+	displayName: siteConfig.name,
+	phoneDisplay: siteConfig.phone,
+	phoneE164: "+18312254344",
+	phoneHref: siteConfig.phoneHref,
+	email: siteConfig.email,
+	emailHref: `mailto:${siteConfig.email}`,
+	hours: siteConfig.hours,
+	address: siteConfig.address,
+	url: siteConfig.url,
+	licenses: siteConfig.licenses,
+	licenseNumber: siteConfig.licenseNumber,
+	/** PNG mark embeds cleanly in vCards across iOS and Android. */
+	photoPath: "/images/brand/apple-touch-icon.png",
+	vcardPath: VCARD_PATH,
+} as const
+
+/**
+ * Encode contact strings so raw HTML / view-source does not contain contiguous
+ * mailto:/tel: targets. Client components decode with the matching helper.
+ * This is deterrent-level protection (naive scrapers), not cryptography.
+ */
+export function encodeContactValue(value: string): string {
+	const key = 37
+	const bytes = Array.from(value, (char, index) => {
+		return (char.charCodeAt(0) ^ (key + (index % 17))) & 255
+	})
+	if (typeof Buffer !== "undefined") {
+		return Buffer.from(bytes).toString("base64")
+	}
+	let binary = ""
+	for (const byte of bytes) binary += String.fromCharCode(byte)
+	return btoa(binary)
+}
+
+export function decodeContactValue(encoded: string): string {
+	let bytes: number[]
+	if (typeof Buffer !== "undefined") {
+		bytes = Array.from(Buffer.from(encoded, "base64"))
+	} else {
+		const binary = atob(encoded)
+		bytes = Array.from(binary, (char) => char.charCodeAt(0))
+	}
+	const key = 37
+	return bytes
+		.map((byte, index) =>
+			String.fromCharCode(byte ^ ((key + (index % 17)) & 255)),
+		)
+		.join("")
+}
+
+/** Pre-encoded payloads shipped to the client (no plaintext tel:/mailto: hrefs). */
+export const contactEncoded = {
+	phoneDisplay: encodeContactValue(contactInfo.phoneDisplay),
+	phoneHref: encodeContactValue(contactInfo.phoneHref),
+	email: encodeContactValue(contactInfo.email),
+	emailHref: encodeContactValue(contactInfo.emailHref),
+	vcardPath: encodeContactValue(contactInfo.vcardPath),
+} as const

--- a/lib/vcard.ts
+++ b/lib/vcard.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+import { contactInfo } from "@/lib/contact"
+import { siteConfig } from "@/lib/site"
+
+/** RFC 6350 line folding (75 octets; continuation lines start with a space). */
+function foldLine(line: string): string {
+	const max = 75
+	if (line.length <= max) return line
+
+	let out = line.slice(0, max)
+	let rest = line.slice(max)
+	while (rest.length > 0) {
+		out += `\r\n ${rest.slice(0, max - 1)}`
+		rest = rest.slice(max - 1)
+	}
+	return out
+}
+
+function escapeText(value: string): string {
+	return value
+		.replace(/\\/g, "\\\\")
+		.replace(/\n/g, "\\n")
+		.replace(/,/g, "\\,")
+		.replace(/;/g, "\\;")
+}
+
+function loadPhotoBase64(): string | null {
+	try {
+		const absolute = path.join(process.cwd(), "public", contactInfo.photoPath)
+		return readFileSync(absolute).toString("base64")
+	} catch {
+		return null
+	}
+}
+
+/**
+ * Build a vCard 3.0 payload with wide device support (iOS, Android, desktop).
+ * PHOTO is embedded as PNG base64 so offline save still includes the logo.
+ */
+export function buildBusinessVCard(): string {
+	const photo = loadPhotoBase64()
+	const { address } = contactInfo
+
+	const lines = [
+		"BEGIN:VCARD",
+		"VERSION:3.0",
+		`N:${escapeText("Plumbing & Septic")};${escapeText("Wade's")};;;`,
+		`FN:${escapeText(contactInfo.displayName)}`,
+		`ORG:${escapeText(contactInfo.displayName)}`,
+		"TITLE:Plumbing and Septic Service",
+		`TEL;TYPE=WORK,VOICE,PREF:${contactInfo.phoneE164}`,
+		`TEL;TYPE=CELL,VOICE:${contactInfo.phoneE164}`,
+		`EMAIL;TYPE=INTERNET,WORK,PREF:${contactInfo.email}`,
+		`ADR;TYPE=WORK:;;${escapeText(address.street)};${escapeText(address.city)};${escapeText(address.region)};${escapeText(address.postalCode)};USA`,
+		`LABEL;TYPE=WORK:${escapeText(address.display)}`,
+		`URL;TYPE=WORK:${siteConfig.url}`,
+		`NOTE:${escapeText(`${contactInfo.licenses}. Hours: ${contactInfo.hours}. ${siteConfig.serviceArea}.`)}`,
+		`UID:urn:uuid:wades-plumbing-${contactInfo.licenseNumber}`,
+		// Fixed revision keeps the route cacheable; bump when contact fields change.
+		"REV:20260730T120000Z",
+	]
+
+	if (photo) {
+		lines.push(foldLine(`PHOTO;ENCODING=b;TYPE=PNG:${photo}`))
+	} else {
+		lines.push(`PHOTO;VALUE=URI:${siteConfig.url}${contactInfo.photoPath}`)
+	}
+
+	lines.push("END:VCARD")
+	return `${lines.join("\r\n")}\r\n`
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Phone and email stay visible; `tel:` / `mailto:` hrefs are applied on the client (deterrent-level scraper protection).
- `/contact.vcf` serves a logo-embedded vCard for save-to-contacts on any phone.
- Virtual business card in the footer and on Contact, redesigned for mobile as one clean contact strip (not a stack of icon tiles).
- **After Save to phone:** when the user returns from the contact sheet (or after a short delay), a bottom sheet prompts them to Call. Browsers cannot detect a completed save, so this is a best-effort nudge.
- Mobile Call CTAs that save a contact use the same prompt; footer top bar dials directly so Save is not duplicated.

## Test plan
- [ ] Phone: footer + Contact card read as one composition; phone number is the clear focus
- [ ] Tap Save to phone → OS contact UI → return to site → “Ready to call?” sheet with Call button
- [ ] If the vCard downloads without leaving the tab, Call prompt still appears after a couple seconds
- [ ] Desktop card still has side actions; Call dials normally
- [ ] `/contact.vcf` still returns `text/vcard` with PHOTO

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

