### PR TITLE
Fix Sitemap footer link returning 404

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,22 +1,13 @@
 import type { MetadataRoute } from "next"
 
-import {
-	getSitemapChunk,
-	getSitemapChunkCount,
-} from "@/lib/sitemap"
+import { buildSitemapEntries } from "@/lib/sitemap"
 
-export async function generateSitemaps() {
-	const count = await getSitemapChunkCount()
-	return Array.from({ length: count }, (_, id) => ({ id }))
-}
-
-export default async function sitemap(props: {
-	id: Promise<string> | string
-}): Promise<MetadataRoute.Sitemap> {
-	const idValue = await props.id
-	const id = Number(idValue)
-
-	if (!Number.isInteger(id) || id < 0) return []
-
-	return getSitemapChunk(id)
+/**
+ * Single sitemap at /sitemap.xml.
+ * Inventory is well under the 50k URL limit, so chunked generateSitemaps
+ * is unnecessary and would leave /sitemap.xml without a working index
+ * (footer and robots.txt both point at the root URL).
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	return buildSitemapEntries()
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -178,11 +178,6 @@ const nextConfig: NextConfig = {
 				permanent: true,
 			},
 			{
-				source: "/sitemap/:id(\\d+).xml",
-				destination: "/sitemap.xml",
-				permanent: true,
-			},
-			{
 				source: "/service-offerings/hydro-jetting-for-drain-clearing",
 				destination: "/service-offerings/hydro-jetting",
 				permanent: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The footer Sitemap control linked to `/sitemap.xml`, but that URL 404ed.

**Cause**
1. `app/sitemap.ts` used `generateSitemaps()`, which only exposes chunk URLs like `/sitemap/0.xml`, not a working root `/sitemap.xml`.
2. `next.config.ts` permanently redirected `/sitemap/:id.xml` → `/sitemap.xml`, so even the chunk URLs ended up on the broken root.

**Fix**
- Serve a single sitemap from `app/sitemap.ts` via `buildSitemapEntries()` (inventory is ~333 URLs, well under the 50k limit).
- Remove the chunk → root redirect. Keep `/wp-sitemap.xml` → `/sitemap.xml` for legacy WordPress URLs.

Footer and `robots.ts` both already point at `/sitemap.xml`, so no link changes were needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

