### PR TITLE
Stop stacking save-contact CTAs across the site

### DIFF
--- a/components/call-button.tsx
+++ b/components/call-button.tsx
@@ -4,7 +4,6 @@ import type { ReactNode } from "react"
 import { Phone } from "@/components/icons"
 
 import { ProtectedContactLink } from "@/components/protected-contact"
-import { SaveContactButton } from "@/components/save-contact-button"
 import { buttonVariants } from "@/components/ui/button"
 import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
@@ -12,76 +11,34 @@ import { cn } from "@/lib/utils"
 type ButtonSize = "default" | "sm" | "lg" | "xl" | "icon"
 
 /**
- * Primary call CTA. Defaults to dialing the phone number on every viewport.
- * Use prefer="vcard" only where save-contact is an intentional secondary action
- * (e.g. the footer business card), not as the main header/hero control.
+ * Primary call CTA — always dials. Save-contact belongs on the contact page
+ * card only (see VirtualBusinessCard), never as a header/hero/footer control.
  */
 export function CallButton({
 	className,
 	size = "xl",
 	variant = "default",
 	showIcon = true,
-	prefer = "dial",
 	desktopLabel,
-	mobileLabel,
 }: {
 	className?: string
 	size?: ButtonSize
 	variant?: "default" | "secondary" | "inverse" | "outline" | "ghost"
 	showIcon?: boolean
-	/** dial: phone link everywhere. vcard: save-contact sheet. auto: legacy split. */
+	/** @deprecated Ignored — CallButton always dials. */
 	prefer?: "auto" | "dial" | "vcard"
 	desktopLabel?: ReactNode
+	/** @deprecated Ignored — CallButton always dials. */
 	mobileLabel?: ReactNode
 }) {
 	const styles = cn(buttonVariants({ size, variant }), className)
 	const dialLabel = desktopLabel ?? `Call ${contactInfo.phoneDisplay}`
-	const vcardLabel = mobileLabel ?? "Save contact"
-	/*
-	  Accessible name must include visible label text (axe label-content-name-
-	  mismatch). Keep the phone number when the visible label is a short CTA.
-	*/
 	const dialAria =
 		typeof dialLabel === "string"
 			? dialLabel.includes(contactInfo.phoneDisplay)
 				? dialLabel
 				: `${dialLabel} ${contactInfo.phoneDisplay}`
 			: `Call ${contactInfo.phoneDisplay}`
-
-	if (prefer === "vcard") {
-		return (
-			<SaveContactButton className={className} size={size} variant={variant}>
-				{vcardLabel}
-			</SaveContactButton>
-		)
-	}
-
-	if (prefer === "auto") {
-		return (
-			<>
-				<span className="sm:hidden">
-					<ProtectedContactLink
-						ariaLabel={dialAria}
-						className={styles}
-						kind="phone"
-					>
-						{showIcon ? <Phone aria-hidden="true" /> : null}
-						{typeof mobileLabel === "string" && mobileLabel !== "Save contact"
-							? mobileLabel
-							: dialLabel}
-					</ProtectedContactLink>
-				</span>
-				<ProtectedContactLink
-					ariaLabel={dialAria}
-					className={cn(styles, "hidden sm:inline-flex")}
-					kind="phone"
-				>
-					{showIcon ? <Phone aria-hidden="true" /> : null}
-					{dialLabel}
-				</ProtectedContactLink>
-			</>
-		)
-	}
 
 	return (
 		<ProtectedContactLink
@@ -99,7 +56,7 @@ export function CallButton({
 	)
 }
 
-/** Icon-only header call control — always dials, never opens save-contact. */
+/** Icon-only header call control — always dials. */
 export function CallIconButton({ className }: { className?: string }) {
 	return (
 		<ProtectedContactLink

--- a/components/content-page.tsx
+++ b/components/content-page.tsx
@@ -156,8 +156,8 @@ export function ContentPage({
 						<p className="spec-label">Reach us</p>
 						<h2 className="type-title">Call, text, or email Wade&apos;s</h2>
 						<p className="type-lead">
-							The number and email are right on the card. You can also save it
-							to your phone if that helps later.
+							Phone and email are on the card below. Saving the contact is
+							optional — calling is the fastest way to get help.
 						</p>
 					</div>
 					<VirtualBusinessCard id="contact-business-card" />

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -4,8 +4,7 @@ import Link from "next/link"
 
 import { CallButton } from "@/components/call-button"
 import { CompanyLogo } from "@/components/company-logos"
-import { ProtectedPhoneText } from "@/components/protected-contact"
-import { VirtualBusinessCard } from "@/components/virtual-business-card"
+import { contactInfo } from "@/lib/contact"
 import { companyNavigation, resourceNavigation, siteConfig } from "@/lib/site"
 
 const serviceLinks = [
@@ -33,24 +32,18 @@ const socialLinks = [
 export function SiteFooter() {
 	return (
 		<footer className="bg-ink text-white">
+			{/*
+			  One dial CTA in the strip — phone number is the label. No save-contact
+			  here; that lives only on the contact page card as a quiet secondary.
+			*/}
 			<div className="bg-primary shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.18)]">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
-					<div>
-						<p className="font-mono text-[0.6875rem] font-semibold tracking-[0.14em] text-white/80 uppercase">
-							{siteConfig.hours}
-						</p>
-						<p className="type-subtitle mt-1 text-white">
-							<ProtectedPhoneText className="text-inherit hover:text-white" />
-						</p>
-					</div>
-					{/*
-					  Explicit ink text on the white plate. This used to inherit
-					  text-foreground, which in dark mode resolves to near-white - an
-					  invisible label on a white button.
-					*/}
+					<p className="font-mono text-[0.6875rem] font-semibold tracking-[0.14em] text-white/80 uppercase">
+						{siteConfig.hours}
+					</p>
 					<CallButton
 						className="text-ink w-full bg-white hover:bg-white/90 sm:w-auto"
-						desktopLabel="Call now"
+						desktopLabel={`Call ${contactInfo.phoneDisplay}`}
 						prefer="dial"
 						size="lg"
 						variant="secondary"
@@ -59,17 +52,6 @@ export function SiteFooter() {
 			</div>
 
 			<div className="container-shell py-[var(--space-section-y-tight)]">
-				<div className="mb-[var(--space-block)]">
-					<p className="text-primary-bright mb-3 font-mono text-[0.6875rem] font-semibold tracking-[0.14em] uppercase">
-						Keep us handy
-					</p>
-					<p className="text-on-dark-muted mb-5 max-w-xl text-sm leading-relaxed">
-						Save Wade&apos;s to your phone, then call or text whenever you need
-						plumbing or septic help.
-					</p>
-					<VirtualBusinessCard id="footer-business-card" tone="dark" />
-				</div>
-
 				<div className="grid gap-[var(--space-block)] sm:grid-cols-2 lg:grid-cols-[minmax(0,1.4fr)_repeat(3,minmax(0,1fr))]">
 					<div>
 						<Link

--- a/components/static-site-footer.tsx
+++ b/components/static-site-footer.tsx
@@ -34,39 +34,25 @@ const socialLinks = [
 export function StaticSiteFooter() {
 	return (
 		<footer className="bg-ink text-white">
+			{/*
+			  Single dial action. Do not stack the phone number, a Call button,
+			  and save-contact in the same strip — that reads as spammy on mobile.
+			*/}
 			<div className="bg-primary shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.18)]">
 				<div className="container-shell flex flex-col items-center justify-between gap-4 py-6 text-center sm:flex-row sm:text-left">
-					<div>
-						<p className="font-mono text-[0.6875rem] font-semibold tracking-[0.14em] text-white/80 uppercase">
-							{siteConfig.hours}
-						</p>
-						<p className="type-subtitle mt-1 text-white">
-							<a
-								aria-label={`Call ${contactInfo.phoneDisplay}`}
-								className="hover:text-white inline-flex min-h-11 items-center text-inherit"
-								href={contactInfo.phoneHref}
-							>
-								{contactInfo.phoneDisplay}
-							</a>
-						</p>
-					</div>
-					<div className="flex w-full flex-col items-stretch gap-2 sm:w-auto sm:items-end">
-						<a
-							className={cn(
-								buttonVariants({ variant: "inverse", size: "lg" }),
-								"bg-white text-ink hover:bg-white/90 inline-flex w-full gap-2 sm:w-auto",
-							)}
-							href={contactInfo.phoneHref}
-						>
-							Call {contactInfo.phoneDisplay}
-						</a>
-						<a
-							className="text-center text-sm font-bold text-white/85 underline-offset-2 hover:text-white hover:underline sm:text-right"
-							href={contactInfo.vcardPath}
-						>
-							Save to contacts
-						</a>
-					</div>
+					<p className="font-mono text-[0.6875rem] font-semibold tracking-[0.14em] text-white/80 uppercase">
+						{siteConfig.hours}
+					</p>
+					<a
+						aria-label={`Call ${contactInfo.phoneDisplay}`}
+						className={cn(
+							buttonVariants({ variant: "inverse", size: "lg" }),
+							"bg-white text-ink hover:bg-white/90 inline-flex w-full gap-2 sm:w-auto",
+						)}
+						href={contactInfo.phoneHref}
+					>
+						Call {contactInfo.phoneDisplay}
+					</a>
 				</div>
 			</div>
 

--- a/components/virtual-business-card.tsx
+++ b/components/virtual-business-card.tsx
@@ -13,9 +13,8 @@ import { contactInfo } from "@/lib/contact"
 import { cn } from "@/lib/utils"
 
 /**
- * Virtual business card: one clean contact composition with save + call.
- * Mobile keeps a single vertical flow (no icon-tile grid). Desktop adds a
- * side action column.
+ * Contact-page card only. Call is the primary action; save-contact is a quiet
+ * text link so it does not compete with dialing.
  */
 export function VirtualBusinessCard({
 	tone = "light",
@@ -57,7 +56,7 @@ export function VirtualBusinessCard({
 									dark ? "text-primary-bright" : "text-primary",
 								)}
 							>
-								Virtual business card
+								Contact card
 							</p>
 							<h2
 								className={cn(
@@ -143,7 +142,6 @@ export function VirtualBusinessCard({
 						</div>
 					</div>
 
-					{/* Call first; save-contact stays secondary so we don't oversell it. */}
 					<div className="grid gap-2 sm:hidden">
 						<CallButton
 							className="w-full"
@@ -151,27 +149,31 @@ export function VirtualBusinessCard({
 							prefer="dial"
 							size="lg"
 						/>
-						<SaveContactButton
-							className="w-full"
-							size="lg"
-							variant={dark ? "inverse" : "outline"}
-						>
-							Save to contacts
-						</SaveContactButton>
 						<ProtectedContactLink
 							ariaLabel={`Email us at ${contactInfo.email}`}
 							className={cn(
-								buttonVariants({ variant: "ghost", size: "lg" }),
+								buttonVariants({ variant: "outline", size: "lg" }),
 								"w-full",
-								dark
-									? "text-on-dark-muted hover:text-white"
-									: "text-muted-foreground",
+								dark ? "border-white/20 text-white" : undefined,
 							)}
 							kind="email"
 						>
 							<Mail aria-hidden="true" />
 							Email us
 						</ProtectedContactLink>
+						<SaveContactButton
+							className={cn(
+								"w-full justify-center text-sm font-bold underline-offset-2 hover:underline",
+								dark
+									? "text-on-dark-muted hover:text-white"
+									: "text-muted-foreground hover:text-foreground",
+							)}
+							showIcon={false}
+							size="sm"
+							variant="ghost"
+						>
+							Save to contacts
+						</SaveContactButton>
 					</div>
 				</div>
 
@@ -187,8 +189,8 @@ export function VirtualBusinessCard({
 							dark ? "text-on-dark-muted" : "text-muted-foreground",
 						)}
 					>
-						Call us anytime. Prefer one tap later? Save the card with our
-						number, email, and address.
+						Call or email anytime. You can also save this card if you want the
+						number handy later.
 					</p>
 					<CallButton
 						className="w-full"
@@ -196,27 +198,31 @@ export function VirtualBusinessCard({
 						prefer="dial"
 						size="lg"
 					/>
-					<SaveContactButton
-						className="w-full"
-						size="lg"
-						variant={dark ? "inverse" : "outline"}
-					>
-						Save to contacts
-					</SaveContactButton>
 					<ProtectedContactLink
 						ariaLabel={`Email us at ${contactInfo.email}`}
 						className={cn(
-							buttonVariants({ variant: "ghost", size: "lg" }),
+							buttonVariants({ variant: "outline", size: "lg" }),
 							"w-full",
-							dark
-								? "text-on-dark-muted hover:text-white"
-								: "text-muted-foreground",
+							dark ? "border-white/20 text-white" : undefined,
 						)}
 						kind="email"
 					>
 						<Mail aria-hidden="true" />
 						Email us
 					</ProtectedContactLink>
+					<SaveContactButton
+						className={cn(
+							"w-full justify-center text-sm font-bold underline-offset-2 hover:underline",
+							dark
+								? "text-on-dark-muted hover:text-white"
+								: "text-muted-foreground hover:text-foreground",
+						)}
+						showIcon={false}
+						size="sm"
+						variant="ghost"
+					>
+						Save to contacts
+					</SaveContactButton>
 				</div>
 			</div>
 		</section>

--- a/content/pages/contact.md
+++ b/content/pages/contact.md
@@ -12,7 +12,7 @@ eyebrow: Call or Text 831.225.4344
 
 ## Contact Wade's Plumbing & Septic
 
-Need a plumber or septic tech in Santa Cruz County or nearby foothill communities? Use the virtual business card above to save our number, email, address, and logo to your phone, or call and text from there. We confirm your address, triage the issue, and get you on the schedule.
+Need a plumber or septic tech in Santa Cruz County or nearby foothill communities? Call or text the number on the card above. We confirm your address, triage the issue, and get you on the schedule.
 
 ## Call or text
 
@@ -76,4 +76,4 @@ We confirm the address and issue when you book, arrive ready to diagnose, explai
 
 ### Can I save your contact on my phone?
 
-Yes. Tap Save to phone on the virtual business card. It opens a contact card with our logo, phone, email, address, website, and license notes so you can call us later without hunting for the number.
+Yes. Under the call and email actions on the card there is an optional “Save to contacts” link. It opens a contact card with our logo, phone, email, and address if you want the number handy later.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cleans up the redundant “Save contact” / dial stacking that made the bottom of pages feel spammy on mobile.

### Changes
- Footer dial strip is hours + one **Call** button — no phone subtitle + Call + Save stack
- Removed the sitewide footer “Keep us handy” virtual business card
- `CallButton` always dials (no vcard/auto mode)
- Save-to-contacts remains only on the **contact page** card as a quiet text link under Call / Email
- Softened contact page copy so call is primary

### Test plan
- [ ] Homepage: end CTA is Call + Send a Message; footer strip is hours + Call only (no Save)
- [ ] Interior page footer: no business card block; strip is Call only
- [ ] `/contact`: card shows Call, Email, then optional “Save to contacts” text link
- [ ] Header never shows “Save contact”

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fb2bb-acee-773a-bc6c-9e9b84252762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

