### PR TITLE
feat(eve): Route default model to GPT-5.6 Terra

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,72 @@ npm run ci:content
 npm run ci:self-hosted-policy
 ```
 
+## Eve SEO Agent
+
+Eve is a private, backend-only SEO operations service at
+`automation/seo-agent`. It has no public UI, CMS, or application database.
+The public site does not import Eve code or expose Eve environment variables.
+Git and the committed `seo/` records remain the source of truth for evidence,
+proposals, approvals, and rollback information.
+
+### What Eve can do today
+
+- Run deterministic local audit fixtures, policy checks, content checks, and
+  Eve evaluations without cloud credentials.
+- Expose private health and readiness endpoints at
+  `/_internal/eve/api/healthz` and `/_internal/eve/api/readyz`.
+- Protect its internal Cron dispatcher at `/_internal/eve/api/cron` using a
+  timing-safe secret comparison.
+- Create durable audit sessions when its runtime dependencies are configured.
+- Enforce observe mode, an audit-only first run, duplicate-run protection,
+  limits, and the default mutation kill switch.
+- Evaluate source policy, content safety, page ownership, internal links,
+  query overlap, and a valid no-change decision in local fixture mode.
+
+### What configuration can enable
+
+The service can make real, read-only research requests only after the owner
+configures a model identity through Vercel OIDC or `AI_GATEWAY_API_KEY`, then
+enables and verifies each least-privilege integration separately. Supported
+read-side integrations include Vercel AI Gateway, GitHub repository inspection,
+Vercel project and deployment inspection, Search Console, PageSpeed Insights,
+and controlled web or browser research. Optional adapters include GA4, Business
+Profile, Local Falcon, Similarweb, Google Trends, tracing, and private Blob
+archiving of already approved redacted evidence bundles.
+
+Each live integration is reported as `LIVE_VERIFIED`, `MOCK_VERIFIED`,
+`BLOCKED_MISSING_CREDENTIALS`, or `FAILED`. A configured variable alone does
+not make an integration live.
+
+### What Eve cannot do today
+
+- It cannot make a model-backed research request until AI Gateway credentials
+  or Vercel OIDC are available to the deployed service.
+- It cannot currently write site content, create a Git branch, or open a
+  content pull request. The installed GitHub Eve tool is intentionally read
+  only, and every current runtime mode remains audit-only.
+- It cannot merge a pull request, push to `main`, deploy production, modify
+  repository or Vercel settings, change secrets, publish to a Business Profile,
+  or bypass a human review.
+- It cannot create new service pages. Any future draft proposal must prefer an
+  evidence-backed update to an existing page, and a new URL is limited to a
+  useful blog post or an explicitly approved landing page.
+
+### Before a live draft-content test
+
+1. Add a fresh `AI_GATEWAY_API_KEY` or enable Vercel OIDC for the production
+   Eve service. Do not reuse credentials pasted into chat or committed files.
+2. Keep `SEO_AGENT_RUN_MODE=propose` only for the approved run, retain
+   `SEO_AGENT_MUTATION_KILL_SWITCH=true` until the guarded publication gateway
+   is reviewed, and leave automatic merge disabled.
+3. Deploy the separately reviewed publication gateway. It must be limited to
+   one draft PR, a nondefault `eve/seo/` branch, one new URL, bounded files,
+   complete evidence, and a human reviewer.
+
+See [`docs/seo-agent/MANUAL_SETUP.md`](docs/seo-agent/MANUAL_SETUP.md) for
+owner setup and [`docs/seo-agent/BUILD_SPEC.md`](docs/seo-agent/BUILD_SPEC.md)
+for the safety contract.
+
 ## CI (self-hosted only)
 
 GitHub Actions workflows run exclusively on **local self-hosted runners** - not

--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -1,5 +1,14 @@
 # Eve SEO Agent Implementation Status
 
+## Phase 30: Live Draft-Content Capability Assessment (2026-08-01)
+
+- State: `BLOCKED_MISSING_CREDENTIALS` for a real blog-post draft PR. The draft-PR writer is intentionally not implemented. No live Eve session, model request, Git branch, content change, or pull request was started by this assessment.
+- Production evidence: at `2026-08-01T10:45Z`, `GET /_internal/eve/api/healthz` returned HTTP `200` with `mode: observe`, `ready: true`, `mutation_kill_switch: true`, and `integration_classification: BLOCKED_MISSING_CREDENTIALS`. Vercel Agent Runs reported zero runs in the preceding day. Production environment metadata confirms the Cron and proposal safety-variable names exist, but neither `AI_GATEWAY_API_KEY` nor `VERCEL_OIDC_TOKEN` is available to the deployed service.
+- Code evidence: `automation/seo-agent/agent/tools/github.ts` exposes the GitHub `repo-explorer` read-only preset only. `agent/tools/orchestrate.ts`, `src/runtime.mjs`, and the runtime channel hard-code audit-only execution. No deployed tool can create a branch, commit Markdown, or open a draft PR. The `propose` mode label does not change that current behavior.
+- Documentation: root `README.md` now distinguishes Eve's currently verified audit and policy capabilities, the read-only integrations that additional configuration can enable, and the operations it intentionally cannot perform.
+- Verification: `npx prettier --no-config --use-tabs --no-semi --single-quote=false --check README.md docs/seo-agent/IMPLEMENTATION_STATUS.md` and `git diff --check` exited `0`. The repository-configured Prettier check could not load the locally absent `prettier-plugin-tailwindcss`; this is a local dependency-install limitation, not a documentation formatting failure.
+- Required next action: configure a fresh model identity through Vercel OIDC or a newly issued `AI_GATEWAY_API_KEY`, then implement, review, and deploy a narrowly scoped publication gateway before requesting one human-approved draft blog-post run. That gateway must retain the mutation kill switch, one-PR and one-URL budget, nondefault `eve/seo/` branch requirement, draft-only PR setting, complete evidence packet, and no merge capability.
+
 ## Phase 29: Production Runtime Probe and Image-Delivery Repair (2026-08-01)
 
 - State: the Eve deployment is `LIVE_VERIFIED` for non-mutating health, readiness, and Cron authentication. The image repair is `MOCK_VERIFIED` by the canonical build and awaits human review in draft PR `#82` before it can reach production.


### PR DESCRIPTION
## Summary

Routes Eve orchestration and writing to the requested `openai/gpt-5.6-terra` model and adds regression coverage to keep that route centralized. It also retains the OIDC health correction and documents the actual operating boundary.

## Live Gateway evidence

- Vercel OIDC authenticated a minimal `openai/gpt-4.1-mini` request: 18 input and 9 output tokens.
- `openai/gpt-5.6-terra` is present in the live Gateway catalog.
- A bounded OIDC generation probe for Terra received HTTP 403, so it is accurately `FAILED` until the Gateway account has access.
- No Eve session, branch, content mutation, or pull request was created by the sidecar.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (103 passing)
- `npm run verify`
- `git diff --check`

`npm run evals` remains blocked only by Eve's existing local Windows absolute-path ESM-loader limitation. Hosted CI must confirm that suite before merge. Root-document formatting could not run in this checkout because the root Prettier plugin dependency is absent; sidecar formatting passed.