### PR TITLE
Fix Eve native schedule handoff

### DIFF
--- a/automation/seo-agent/agent/schedules/audit.ts
+++ b/automation/seo-agent/agent/schedules/audit.ts
@@ -5,13 +5,18 @@ export default defineSchedule({
 	// 16:17 UTC every Monday. Human setup must keep this schedule disabled until
 	// the first manually initiated audit-only run has been reviewed.
 	cron: "17 16 * * 1",
-	async run({ receive, appAuth }) {
+	run({ receive, waitUntil, appAuth }) {
 		// Native Eve/Vercel schedules are platform-authenticated. The external
 		// /api/cron fallback separately verifies CRON_SECRET before dispatch.
-		await receive(runtime, {
-			auth: appAuth,
-			message: "Start the bounded audit-only runtime schedule.",
-			target: { source: "EVE_NATIVE_CRON" },
-		});
+		// Eve schedule handlers must register the detached durable handoff with
+		// waitUntil. This allows the Cron task to return promptly while Vercel
+		// continues the receive operation and records the Agent Run.
+		waitUntil(
+			receive(runtime, {
+				auth: appAuth,
+				message: "Start the bounded audit-only runtime schedule.",
+				target: { source: "EVE_NATIVE_CRON" },
+			}),
+		);
 	},
 });

--- a/automation/seo-agent/tests/eve-build-summary.test.mjs
+++ b/automation/seo-agent/tests/eve-build-summary.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import test from "node:test";
 import { verifyEveBuildSummary } from "../scripts/verify-eve-manifest.mjs";
 
@@ -45,4 +47,14 @@ test("Eve 0.29 build summaries retain the required runtime contract", () => {
 			}),
 		/readyz channel/,
 	);
+});
+
+test("the native schedule hands durable work to Eve through waitUntil", () => {
+	const scheduleSource = readFileSync(
+		resolve(import.meta.dirname, "../agent/schedules/audit.ts"),
+		"utf8",
+	);
+	assert.match(scheduleSource, /run\(\{ receive, waitUntil, appAuth \}\)/);
+	assert.match(scheduleSource, /waitUntil\(\s*receive\(runtime,/s);
+	assert.match(scheduleSource, /target: \{ source: "EVE_NATIVE_CRON" \}/);
 });

--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -1,5 +1,13 @@
 # Eve SEO Agent Implementation Status
 
+## Phase 46: Native Schedule Durable Handoff Repair (2026-08-02)
+
+- State: READY_FOR_HUMAN_REVIEW. A real Production native-Cron invocation was accepted at `2026-08-02T18:48:35.600Z`, but Vercel recorded zero Eve Agent Runs. This is `FAILED` live evidence for the pre-repair schedule path, not a credential or approval failure.
+- Cause and correction: the installed Eve `0.29.4` schedule API requires `waitUntil(receive(...))` to keep a schedule's durable handoff alive after the Cron task returns. `agent/schedules/audit.ts` had awaited `receive(...)` directly. The repair now registers that handoff with `waitUntil`, and a regression test asserts the supported API shape and trusted native target.
+- Verification: `npm run format:check` exit `0`; `npm run typecheck` exit `0`; `npm run test` exit `0` with `110` passing tests; `npm run build` exit `0` and verified the compiled Eve manifest. These are `MOCK_VERIFIED` for the correction. The native Cron acceptance and zero Agent Runs are `LIVE_VERIFIED` observations of the defect.
+- Production configuration: `SEO_AGENT_LIVE_READS_APPROVED=true`, `SEO_AGENT_LIVE_READS_APPROVED_RUN_ID=audit-2026-08-02`, and `SEO_AGENT_NATIVE_SCHEDULE_JOB=audit` were set only to authorize the required first audit. They do not enable mutation or GitHub writes. The unchanged Production redeploy is `dpl_49m6nMkyqtQFBZkHMKyZLrUhovz2`.
+- Next exact action: merge and deploy the schedule-handoff repair, trigger the one native Cron path again, confirm a durable audit Agent Run, and only then enable the exact one-time draft-PR gates for a human-reviewable blog-post PR.
+
 ## Phase 45: Single Native Proposal Proof Repair (2026-08-02)
 
 - State: COMPLETE for the local implementation (`MOCK_VERIFIED`); deployment and the first live proposal proof remain pending human review of the repair PR.


### PR DESCRIPTION
## Summary

Uses Eve's supported waitUntil(receive(...)) schedule handoff so a native Vercel Cron invocation can start and retain a durable Agent Run.

## Evidence

- 
pm run format:check (sidecar): passed
- 
pm run typecheck (sidecar): passed
- 
pm run test (sidecar): 110 passed
- 
pm run build (sidecar): passed
- Live native Cron invocation at 2026-08-02T18:48:35.600Z was accepted but produced zero Agent Runs before this fix.

## Scope

No content mutation, GitHub publishing, merge, or direct main write is enabled by this change. After merge and deployment, the next step is a required audit-only run, then one human-reviewable blog-post draft PR.