### PR TITLE
fix(eve): Reuse existing Connect draft branch/PR on GitHub 422

### DIFF
--- a/automation/seo-agent/src/publishing.mjs
+++ b/automation/seo-agent/src/publishing.mjs
@@ -1,6 +1,6 @@
 import { assertTruthState, authorizeAction } from "./policy.mjs";
 import { assertMarkdownChangeSet } from "./markdown-change-set.mjs";
-import { requestJson } from "./adapters.mjs";
+import { IntegrationError, requestJson } from "./adapters.mjs";
 import { createRunBudget } from "./run-controls.mjs";
 
 const SAFE_DRAFT_BRANCH =
@@ -70,6 +70,26 @@ function branchPath(branch) {
 		.split("/")
 		.map((segment) => encodeURIComponent(segment))
 		.join("/");
+}
+
+function assertDraftPullRequestShape(pullRequest, branch, classification) {
+	if (
+		pullRequest?.draft !== true ||
+		!Number.isInteger(pullRequest?.number) ||
+		pullRequest.number < 1 ||
+		typeof pullRequest?.html_url !== "string" ||
+		!pullRequest.html_url.startsWith("https://") ||
+		pullRequest?.base?.ref !== "main" ||
+		pullRequest?.head?.ref !== branch
+	) {
+		throw new Error("GitHub did not return the requested draft pull request.");
+	}
+	return Object.freeze({
+		classification,
+		draft: true,
+		number: pullRequest.number,
+		url: pullRequest.html_url,
+	});
 }
 
 /**
@@ -173,23 +193,48 @@ export function createGithubDraftPublisher({
 					"GitHub main changed before the draft branch could be created.",
 				);
 			}
-			const created = await request(
-				`${base}/git/refs`,
-				{
-					method: "POST",
-					body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: fromSha }),
-				},
-				"GitHub draft feature branch create",
-			);
-			if (created?.object?.sha !== fromSha) {
-				throw new Error("GitHub did not create the requested draft branch.");
+			try {
+				const created = await request(
+					`${base}/git/refs`,
+					{
+						method: "POST",
+						body: JSON.stringify({ ref: `refs/heads/${branch}`, sha: fromSha }),
+					},
+					"GitHub draft feature branch create",
+				);
+				if (created?.object?.sha !== fromSha) {
+					throw new Error("GitHub did not create the requested draft branch.");
+				}
+				return Object.freeze({
+					classification,
+					branch,
+					base_sha: fromSha,
+					write_performed: true,
+				});
+			} catch (error) {
+				// Same-day Cron retries collide on eve/seo/YYYY-MM-DD-<slug>.
+				// Reuse the existing feature branch; staging commits on top.
+				if (!(error instanceof IntegrationError) || error.status !== 422) {
+					throw error;
+				}
+				const existing = await request(
+					`${base}/git/ref/heads/${branchPath(branch)}`,
+					{ method: "GET" },
+					"GitHub existing draft branch read",
+				);
+				if (!SAFE_SHA.test(existing?.object?.sha ?? "")) {
+					throw new Error(
+						"GitHub reported the draft branch exists but returned no commit SHA.",
+					);
+				}
+				return Object.freeze({
+					classification,
+					branch,
+					base_sha: existing.object.sha,
+					write_performed: false,
+					reused_existing_branch: true,
+				});
 			}
-			return Object.freeze({
-				classification,
-				branch,
-				base_sha: fromSha,
-				write_performed: true,
-			});
 		},
 
 		async stageMarkdownChangeSet({ branch, changeSet }) {
@@ -284,39 +329,43 @@ export function createGithubDraftPublisher({
 			if (typeof body !== "string" || !body.trim()) {
 				throw new Error("GitHub draft pull request body is required.");
 			}
-			const pullRequest = await request(
-				`${base}/pulls`,
-				{
-					method: "POST",
-					body: JSON.stringify({
-						title,
-						body,
-						head: branch,
-						base: "main",
-						draft: true,
-					}),
-				},
-				"GitHub draft pull request create",
-			);
-			if (
-				pullRequest?.draft !== true ||
-				!Number.isInteger(pullRequest?.number) ||
-				pullRequest.number < 1 ||
-				typeof pullRequest?.html_url !== "string" ||
-				!pullRequest.html_url.startsWith("https://") ||
-				pullRequest?.base?.ref !== "main" ||
-				pullRequest?.head?.ref !== branch
-			) {
-				throw new Error(
-					"GitHub did not return the requested draft pull request.",
+			try {
+				const pullRequest = await request(
+					`${base}/pulls`,
+					{
+						method: "POST",
+						body: JSON.stringify({
+							title,
+							body,
+							head: branch,
+							base: "main",
+							draft: true,
+						}),
+					},
+					"GitHub draft pull request create",
 				);
+				return assertDraftPullRequestShape(pullRequest, branch, classification);
+			} catch (error) {
+				if (!(error instanceof IntegrationError) || error.status !== 422) {
+					throw error;
+				}
+				const head = `${owner}:${branch}`;
+				const existing = await request(
+					`${base}/pulls?state=open&head=${encodeURIComponent(head)}&base=main&per_page=5`,
+					{ method: "GET" },
+					"GitHub existing draft pull request lookup",
+				);
+				const match = Array.isArray(existing)
+					? existing.find(
+							(item) =>
+								item?.draft === true &&
+								item?.head?.ref === branch &&
+								item?.base?.ref === "main",
+						)
+					: null;
+				if (!match) throw error;
+				return assertDraftPullRequestShape(match, branch, classification);
 			}
-			return Object.freeze({
-				classification,
-				draft: true,
-				number: pullRequest.number,
-				url: pullRequest.html_url,
-			});
 		},
 	});
 }

--- a/automation/seo-agent/tests/policy.test.mjs
+++ b/automation/seo-agent/tests/policy.test.mjs
@@ -469,6 +469,92 @@ test("GitHub publisher creates a draft branch from the current main SHA without 
 	});
 });
 
+test("GitHub publisher reuses an existing draft branch after create HTTP 422", async () => {
+	const mainSha = "a".repeat(40);
+	const existingSha = "b".repeat(40);
+	const requests = [];
+	const publisher = createGithubDraftPublisher({
+		repository: "byronwade/wadesplumbingandseptic.com",
+		accessTokenProvider: async () => "fixture-connect-token",
+		classification: "MOCK_VERIFIED",
+		enabled: true,
+		mutationMode: "enabled",
+		mutationKillSwitch: false,
+		fetchImpl: async (url, init) => {
+			requests.push({ url: String(url), init });
+			if (
+				init.method === "GET" &&
+				String(url).endsWith("/git/ref/heads/main")
+			) {
+				return jsonResponse({ object: { sha: mainSha } });
+			}
+			if (init.method === "POST" && String(url).endsWith("/git/refs")) {
+				return jsonResponse({ message: "Reference already exists" }, 422);
+			}
+			if (
+				init.method === "GET" &&
+				String(url).includes("/git/ref/heads/eve/seo/2026-08-01-guarded-post")
+			) {
+				return jsonResponse({ object: { sha: existingSha } });
+			}
+			throw new Error(`Unexpected GitHub request: ${init.method} ${url}`);
+		},
+	});
+	const branch = await publisher.createBranch({
+		branch: "eve/seo/2026-08-01-guarded-post",
+		fromSha: mainSha,
+	});
+	assert.deepEqual(branch, {
+		classification: "MOCK_VERIFIED",
+		branch: "eve/seo/2026-08-01-guarded-post",
+		base_sha: existingSha,
+		write_performed: false,
+		reused_existing_branch: true,
+	});
+	assert.equal(requests.length, 3);
+});
+
+test("GitHub publisher returns an existing open draft PR after create HTTP 422", async () => {
+	const publisher = createGithubDraftPublisher({
+		repository: "byronwade/wadesplumbingandseptic.com",
+		accessTokenProvider: async () => "fixture-connect-token",
+		classification: "MOCK_VERIFIED",
+		enabled: true,
+		mutationMode: "enabled",
+		mutationKillSwitch: false,
+		fetchImpl: async (url, init) => {
+			if (init.method === "POST" && String(url).endsWith("/pulls")) {
+				return jsonResponse({ message: "Validation Failed" }, 422);
+			}
+			if (init.method === "GET" && String(url).includes("/pulls?")) {
+				return jsonResponse([
+					{
+						draft: true,
+						number: 102,
+						html_url:
+							"https://github.com/byronwade/wadesplumbingandseptic.com/pull/102",
+						base: { ref: "main" },
+						head: { ref: "eve/seo/2026-08-03-fixture-post" },
+					},
+				]);
+			}
+			throw new Error(`Unexpected GitHub request: ${init.method} ${url}`);
+		},
+	});
+	const result = await publisher.createPullRequest({
+		branch: "eve/seo/2026-08-03-fixture-post",
+		title: "SEO: fixture post",
+		body: "Draft body",
+		draft: true,
+	});
+	assert.deepEqual(result, {
+		classification: "MOCK_VERIFIED",
+		draft: true,
+		number: 102,
+		url: "https://github.com/byronwade/wadesplumbingandseptic.com/pull/102",
+	});
+});
+
 test("draft publisher forwards only a complete draft packet and rejects non-draft or malformed gateway results", async () => {
 	const changeSet = createChangeSet();
 	const packet = createPacket(changeSet);

--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -1,5 +1,6 @@
 # Eve SEO Agent Implementation Status
 
+<<<<<<< HEAD
 ## Phase 66: Task 2 PageSpeed LIVE_VERIFIED (2026-08-03)
 
 - State: COMPLETE for Task 2 live proof (`LIVE_VERIFIED`).
@@ -51,6 +52,17 @@
 - After a `LIVE_VERIFIED` response: reset `SEO_AGENT_LIVE_READS_APPROVED=false` and remove the approved run ID. Do not start Task 2 until that proof exists.
 - Out of scope (Task 3): wiring GSC into topic selection.
 - Next exact action: human merge/deploy this PR, then run the Production live-probe URL once and record the redacted classification.
+=======
+## Phase 54: Live Connect Draft PR Proof (2026-08-03)
+
+- State: LIVE_VERIFIED for Cron → Vercel Connect → draft PR. Not a fixture result.
+- Connect: team `wades-web-dev` connector `github/wadesplumbingandseptic-com` (`scl_FVfVjQbQtfeqYXRbfvxCrA`), GitHub App `gitwadesplumbingandseptic-com`, installation `150943643` on `byronwade`, attached to project `wadesplumbingandseptic-com` for Production and Preview.
+- Production health before proof: `mode: propose`, `ready: true`, `mutation_kill_switch: false`.
+- Commands: `vercel crons run "/eve/v1/cron/mztlWjGEvDDzWJTu64vs_D4R0wSVHIOJ1Cxo9o6r_VI" --project wadesplumbingandseptic-com --scope wades-web-dev` at `2026-08-03T12:50:08.094Z`. Agent Run `wrun_41KZ3TS9TB0GQPT2K1YEX9SMHQ` completed in `30.7s` on deployment `dpl_3ZTdJevhxmAQwp7xv1vqW5zfTVF9`.
+- Draft PR: [#102](https://github.com/byronwade/wadesplumbingandseptic.com/pull/102) opened by `gitwadesplumbingandseptic-com[bot]` on `eve/seo/2026-08-03-home-plumbing-hosting-checklist-2026-08-03` with `content/posts/home-plumbing-hosting-checklist-2026-08-03.md`. Draft only; no merge and no `main` write.
+- Earlier same-day failure: Agent Run `wrun_41KZ3TN9860GSFRYR8Q3EV14EK` hit GitHub HTTP `422` because the interim manual `eve/seo/...` branch already existed. After that branch was removed, the second Cron succeeded. Follow-up code reuses an existing draft branch or open draft PR on create `422` so same-day retries do not fail closed.
+- Next exact action: human review of PR `#102` for content; merge the idempotent publisher repair when ready.
+>>>>>>> e34d2e3 (fix(eve): Reuse existing Connect draft branch/PR on GitHub 422)
 
 ## Phase 53: Remove Draft-PR Safety Blocks (2026-08-03)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Live Cron → Vercel Connect draft PR is working. Proof: draft PR [#102](https://github.com/byronwade/wadesplumbingandseptic.com/pull/102) opened by `gitwadesplumbingandseptic-com[bot]` after Cron at `2026-08-03T12:50:08Z` (Agent Run `wrun_41KZ3TS9TB0GQPT2K1YEX9SMHQ`).

An earlier same-day run failed with GitHub HTTP 422 because the interim manual `eve/seo/...` branch already existed. This change makes `createBranch` and `createPullRequest` reuse an existing draft branch or open draft PR on create 422 so same-day Cron retries do not fail closed.

## Evidence

- Production health: `mode: propose`, `mutation_kill_switch: false`
- Connect: `github/wadesplumbingandseptic-com` on `wades-web-dev`, app `gitwadesplumbingandseptic-com`, installation `150943643`
- Draft PR #102 on `eve/seo/2026-08-03-home-plumbing-hosting-checklist-2026-08-03`
- Status recorded in `docs/seo-agent/IMPLEMENTATION_STATUS.md` Phase 54 as `LIVE_VERIFIED`

## Test plan

- [x] Focused publisher tests for branch/PR 422 reuse
- [x] Sidecar `format:check` and full test suite pass locally
- [ ] Human review of content PR #102 (separate from this repair)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc527-ee67-7312-924c-204c4445aab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc527-ee67-7312-924c-204c4445aab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

