### PR TITLE
docs(eve): Sequential integration rollout tasks (one PR each)

### DIFF
--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -1,5 +1,64 @@
 # Eve SEO Agent Implementation Status
 
+## Phase 61: Sequential Integration Rollout Task Board (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW. Owner asked for a task per recommended integration, each with its own PR, thorough tests, and live confirmation before the next feature starts. Search Console and PageSpeed credentials were reported already granted.
+- Branch: `cursor/integration-rollout-tasks-aab8`.
+- Changed scope: added `docs/seo-agent/INTEGRATION_ROLLOUT.md` with 14 sequenced tasks (Search Console live first, then PageSpeed live, then wiring PRs, then browser/GA4/Local Falcon/GBP/SERP/Trends/judge/indexation/observation/images). Rules require one feature per PR and a truthful `LIVE_VERIFIED` (or recorded blocker) before the next task.
+- Credential check: Production env for `wadesplumbingandseptic-com` contains `GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`, `PAGESPEED_API_KEY`, and the Search Console / PageSpeed enable flags, plus live-read approval vars. Values were not logged. Neither adapter is treated as `LIVE_VERIFIED` until a redacted live probe succeeds.
+- Verification: documentation-only change; no adapter code change in this phase. This is planning evidence, not a live integration proof.
+- Next exact action: human review of the task board, then start Task 1 only (Search Console live probe) on a dedicated branch/PR.
+
+## Phase 60: Proposal Generation Token Safeguards (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW. Owner asked to confirm the generation pipeline is careful with tokens and to add safeguards so Eve cannot accidentally burn the session budget on wasteful generation. Follow-up: quality remains more important than thrift.
+- Branch: `cursor/eve-blog-quality-aab8`.
+- Changed scope: added `src/generation-guards.mjs` with proposal-stage waste ceilings. Quality-first budgets: write **6,500**, expand **4,000**, expand-prompt draft ceiling **28,000** chars, reserved output **20,000**, max **5** model calls. Safeguards that remain: skip obvious topic-model re-ranks, no-progress expand stop, structure-preserving truncation only for runaway input, and fallback calls billed to the same guard. Expand prompts explicitly prioritize completeness over brevity. PR briefs report generation spend.
+- Verification: with Node from the environment `PATH`, sidecar `npm test` exited `0` (`144/144` passing), including quality-first budget floors, structure-preserving truncation, and no-progress expand stop. This remains `MOCK_VERIFIED`; AI Gateway is not called by these fixtures.
+- Next exact action: human review of PR #104 (blog quality + demand + autonomy + expand + token safeguards). No merge/deploy by Eve.
+
+## Phase 59: Expand-Existing Peer Review Instead of Full Rewrites (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW. Owner asked Eve to peer-review and expand good drafts for SEO depth instead of rewriting whole posts when they are only too thin or missing sections.
+- Correction: `src/draft-revision.mjs` classifies expandable quality gaps (`TOO_THIN`, FAQ/section/link/must-cover gaps, local/meta gaps) versus fatal claim failures. Proposal runs now peer-review the existing draft and run up to two expand/revise rounds with a smaller token budget and preserve-first prompts. Fatal claim failures still reject immediately with no rewrite loop.
+- PR briefs record expansion rounds so reviewers can see that Eve added depth instead of starting over.
+- Verification: with Node `v24.14.0`, sidecar `npm test` exited `0` (`135/135` passing), including expand-existing and fatal-claim non-expand coverage.
+- Next exact action: merge/deploy with prior brief/autonomy work, then confirm a live draft that needed depth shows expansion rounds in the PR body.
+
+## Phase 58: Detailed Draft PR Briefs (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW. Owner asked for detailed PR briefs that explain what Eve did, why it chose the topic over alternatives, why the post matters, and how it helps SEO.
+- Correction: Connect draft PR bodies now use `buildDraftPrBrief` with reviewer sections for run actions, timing importance, alternatives considered/skipped, SEO mechanics, expected observation window, and execution evidence, while keeping the required packet markers.
+- Topic decisions also capture `why_over_others` and `seo_value` for the brief.
+- Verification: with Node `v24.14.0`, sidecar `npm test` exited `0` (`130/130` passing), including detailed brief packet marker coverage.
+- Next exact action: merge/deploy with prior autonomy work, then confirm the next live draft PR body contains the detailed brief sections.
+
+## Phase 57: Fully Autonomous Research and Topic Decisions (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW. Owner direction: nothing in the proposal path should be an owner option or unavailable toggle. Eve must research and decide automatically.
+- Correction: standing Production propose auto-enables community browser research with versioned hosts (`COMMUNITY_RESEARCH_DOMAINS`). Proposal runs attach the browser research adapter by default (fixtures may pass `null` only for offline tests). Eve also runs an autonomous model topic decision over viable candidates; score ranking remains fallback only when the model cannot return a valid id. Writer prompts receive decision rationale and research notes.
+- Remaining human boundary: draft PR merge/release only. Eve still cannot write `main`, merge, or deploy.
+- Verification: with Node `v24.14.0`, sidecar `npm test` exited `0` (`129/129` passing). Classification for automatic research/decision wiring is `MOCK_VERIFIED` until the next live Cron draft is reviewed.
+- Next exact action: merge and deploy, run Eve Cron, confirm the draft PR packet shows model topic decision plus automatic demand research without owner env toggles.
+
+## Phase 56: Automatic Local Demand and Community Timing (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW / extended by Phase 57. Owner asked for a more advanced automatic research path: holidays, trending concepts, and Santa Cruz County community events (including Capitola Art & Wine) so neighbors find and click the site.
+- Correction: Eve proposal selection now merges a versioned local demand calendar (`seo/manifests/local-demand-calendar.json`) and trending local concepts (`seo/manifests/trending-local-concepts.json`) ahead of the evergreen catalog. Active windows cover Independence Day, Labor Day, Thanksgiving, New Year, Watsonville Strawberry Festival, Capitola Art & Wine, Santa Cruz County Fair, Open Studios, rainy season, and summer visitor hosting, plus hard-water, vacation-rental, ADU, and storm-week trend concepts.
+- Runtime: demand timing is automatic from versioned manifests. Phase 57 removes the owner browser-research toggle requirement for standing propose.
+- Quality: demand-timed drafts must name the community event/holiday/trend, keep people-first depth gates, and reject fake event affiliation claims.
+- Verification: with Node `v24.14.0`, sidecar `npm test` exited `0` (`127/127` passing before Phase 57).
+- Next exact action: complete Phase 57 merge/deploy proof.
+
+## Phase 55: Blog Generation Quality Rebuild (2026-08-03)
+
+- State: READY_FOR_HUMAN_REVIEW / extended by Phase 56. Owner closed the thin Connect draft (#102) and asked for people-first SEO content that can compete: more unique pages, stronger click appeal, and enough depth to satisfy helpful-content expectations.
+- Live proof context: Cron → Connect previously opened draft PR [#102](https://github.com/byronwade/wadesplumbingandseptic.com/pull/102) via `gitwadesplumbingandseptic-com[bot]` (Agent Run `wrun_41KZ3TS9TB0GQPT2K1YEX9SMHQ`). That post was generic, non-local, thinly linked, and not worth keeping. PRs `#102` and `#101` are closed; the colliding `eve/seo/...hosting-checklist...` branch was deleted.
+- Root cause: the live Cron path used a hardcoded hosting-checklist topic, a generic anti-local writer prompt, a single home link, and fallback publishing that could open a draft PR from junk Markdown.
+- Correction: `src/blog-opportunity.mjs` now holds a 10-topic Santa Cruz County catalog with click titles, CTR meta hooks, unique-value briefs, must-cover points, and people-also-ask questions. Selection stays inventory-aware. The writer brief targets people-first helpful content. Publish gates require about `1,400`+ words, `7`+ H2s, Quick Answer, unique-value section, `5`+ FAQ answers, `4`+ planned internal links, local meta description, and reject generic filler or unsupported claims. Writer max output tokens raised to `6,500`. Junk drafts still return `REJECTED_DRAFT_QUALITY` with no Connect PR.
+- Verification: with Node `v24.14.0`, sidecar `npm test` exited `0` (`122/122` passing originally; Phase 56 raises the suite to `127/127`).
+- Next exact action: complete Phase 56 merge/deploy proof.
+
 ## Phase 53: Remove Draft-PR Safety Blocks (2026-08-03)
 
 - State: READY_FOR_HUMAN_REVIEW. Owner asked to remove safety guards so Eve can just open a draft PR.

--- a/docs/seo-agent/INTEGRATION_ROLLOUT.md
+++ b/docs/seo-agent/INTEGRATION_ROLLOUT.md
@@ -1,0 +1,209 @@
+# Eve Integration Rollout Tasks
+
+Sequential, one-feature-at-a-time rollout. **Do not start the next task until the current task has a dedicated PR, thorough tests, and a truthful live proof.**
+
+## Rules
+
+1. **One feature = one PR.** No bundling unrelated adapters.
+2. **Prove before wiring.** Live adapter read/`LIVE_VERIFIED` comes before using that evidence to change topic selection or draft content.
+3. **Fail closed.** If credentials, scopes, or probes fail, mark `BLOCKED` and stop. Do not fake `LIVE_VERIFIED`.
+4. **Offline first.** Deterministic sidecar tests and fixtures must pass before any Production live probe.
+5. **Reset one-time live-read approval** after each probe review (`SEO_AGENT_LIVE_READS_APPROVED=false`, remove run ID).
+6. **Human merge only.** Eve still cannot write `main`, merge, or deploy.
+7. **Quality first.** Integrations exist to improve topic choice and draft quality, not to burn tokens on unused data.
+
+## Credential snapshot (2026-08-03)
+
+Checked Production env var **names** for `wadesplumbingandseptic-com` (values not logged):
+
+| Integration | Credential present | Enable flag present | Live verified? |
+| --- | --- | --- | --- |
+| Search Console (`GOOGLE_SERVICE_ACCOUNT_EMAIL`, `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`) | Yes | `SEO_AGENT_ENABLE_SEARCH_CONSOLE` present | **No** (config only; not proven) |
+| PageSpeed (`PAGESPEED_API_KEY`) | Yes | `SEO_AGENT_ENABLE_PAGESPEED` present | **No** (key stored; flag historically off / unproven) |
+| Live-read approval vars | Present | `SEO_AGENT_LIVE_READS_APPROVED` + run ID exist | Must be set intentionally per probe |
+
+Sensitive flag values are encrypted and were not decoded here. Treat enablement as unproven until a redacted live probe returns `LIVE_VERIFIED`.
+
+---
+
+## Task 1 — Search Console live verification
+
+- **Status:** `READY_TO_START` (credentials appear present)
+- **PR:** `cursor/eve-search-console-live-aab8` (dedicated)
+- **Goal:** Confirm the Search Console adapter can perform a bounded, read-only live request and return redacted `LIVE_VERIFIED` evidence.
+- **Out of scope:** Changing topic selection or writer prompts (Task 3).
+- **Work**
+  - Confirm service-account property access for the Wade site.
+  - Enable only `SEO_AGENT_ENABLE_SEARCH_CONSOLE=true` for one approved Production run ID.
+  - Run `npm --prefix automation/seo-agent run live:probe -- --execute --run-id=<exact-id>`.
+  - Keep mutation/publish off. Observe-only for this probe unless an existing propose path is unrelated and already approved.
+  - Record redacted evidence in `IMPLEMENTATION_STATUS.md`.
+  - Reset live-read approval after review.
+- **Acceptance**
+  - Offline adapter/probe fixtures pass.
+  - Live result classifies Search Console as `LIVE_VERIFIED` (not `BLOCKED_MISSING_CREDENTIALS` / `FAILED`).
+  - No content write, draft PR, merge, or deploy from this task.
+- **Exit gate:** Task 2 may start only after this PR is human-merged or explicitly deferred with a recorded blocker.
+
+## Task 2 — PageSpeed Insights live verification
+
+- **Status:** `BLOCKED_BY_PRIOR` until Task 1 exits
+- **PR:** dedicated PageSpeed branch
+- **Goal:** Confirm PageSpeed API key works for a bounded URL audit and returns redacted `LIVE_VERIFIED` evidence.
+- **Out of scope:** Wiring into proposal QA (Task 4).
+- **Work**
+  - Enable only `SEO_AGENT_ENABLE_PAGESPEED=true` for one approved run ID (Search Console may stay enabled if already proven, but do not mix new wiring).
+  - Probe one owned URL (homepage or a stable service page).
+  - Record Core Web Vitals / score summary as redacted evidence.
+  - Reset live-read approval after review.
+- **Acceptance**
+  - Offline PageSpeed fixtures pass.
+  - Live PageSpeed = `LIVE_VERIFIED`.
+  - No content mutation.
+- **Exit gate:** Task 3 only after this task exits cleanly or is explicitly blocked with owner direction.
+
+## Task 3 — Wire Search Console into topic selection
+
+- **Status:** `BLOCKED_BY_PRIOR` until Task 1 is `LIVE_VERIFIED`
+- **PR:** dedicated “GSC → opportunity ranking” branch
+- **Goal:** Use live (or cached redacted-run) Search Console query/page evidence to prefer topics and existing-page improvements that already show demand.
+- **Acceptance**
+  - Deterministic fixtures with mocked GSC rows.
+  - Fail closed when GSC is unavailable (calendar/catalog fallback remains truthful).
+  - PR brief cites GSC-derived rationale without leaking raw sensitive query dumps.
+  - No live claim without Task 1 proof.
+
+## Task 4 — Wire PageSpeed into draft/preview QA
+
+- **Status:** `BLOCKED_BY_PRIOR` until Task 2 is `LIVE_VERIFIED`
+- **PR:** dedicated PageSpeed QA branch
+- **Goal:** After a draft exists (or on preview audit), record PageSpeed evidence and fail closed on severe regressions for owned URLs under review.
+- **Acceptance**
+  - Mocked PSI fixtures; live path only when enabled + approved.
+  - Does not block draft PR creation on PSI outage; classifies truthfully.
+  - Findings appear in reviewer brief / audit manifest.
+
+## Task 5 — Browser research deepening (+ Browserbase optional)
+
+- **Status:** `BLOCKED_BY_PRIOR` until Tasks 1–4 exit (or owner reorders after GSC/PSI)
+- **PR:** dedicated browser-research branch
+- **Goal:** Strengthen allowlisted community/event corroboration used in demand-timed posts. Optionally prove Browserbase for JS-heavy pages.
+- **Acceptance**
+  - Domain allowlist + injection escalation fixtures still pass.
+  - Live HTTP research or Browserbase session classified truthfully.
+  - Writer still cannot invent sponsorship/affiliation.
+
+## Task 6 — GA4 read-only engagement signals
+
+- **Status:** `BLOCKED_BY_PRIOR`
+- **PR:** dedicated GA4 branch
+- **Goal:** Live-verify GA4, then (same task only after live proof) use aggregate engagement to prefer expanding winners / avoid weak repeats.
+- **Acceptance**
+  - Credential + property scoped read-only.
+  - Offline fixtures + one `LIVE_VERIFIED` probe before any ranking weight ships.
+  - No PII in manifests.
+
+## Task 7 — Local Falcon (local pack / geo rank)
+
+- **Status:** `BLOCKED_BY_PRIOR`
+- **PR:** dedicated Local Falcon branch
+- **Goal:** Live-verify local-rank reads for Santa Cruz County plumbing/septic, then use for service-page refresh priority (existing page first).
+- **Acceptance**
+  - Optional adapter remains disabled by default until proven.
+  - Evidence is gap-analysis only; no competitor-copying.
+
+## Task 8 — Google Business Profile Performance
+
+- **Status:** `BLOCKED_BY_PRIOR`
+- **PR:** dedicated GBP branch
+- **Goal:** Live-verify read-only Business Profile performance / search terms; feed FAQ and local topic ideas.
+- **Acceptance**
+  - Read-only scope; redacted evidence.
+  - No autonomous GBP posts or reply mutations.
+
+## Task 9 — SERP / People Also Ask API
+
+- **Status:** `BLOCKED_BY_PRIOR`
+- **PR:** dedicated SERP provider branch (SerpAPI, DataForSEO, or reviewed equivalent)
+- **Goal:** For the already-chosen topic, fetch PAA / related queries / ranking SERP context into the writer brief.
+- **Acceptance**
+  - New adapter with allowlist, budgets, and untrusted-data handling.
+  - Offline fixtures first; one live probe; then wire into writer brief in the same PR only after live proof in that PR’s evidence section.
+  - Competitor pages = gap analysis only.
+
+## Task 10 — Google Trends (or approved Trends proxy)
+
+- **Status:** `BLOCKED_BY_PRIOR`
+- **PR:** dedicated Trends branch
+- **Goal:** Replace or corroborate hand-maintained trend windows with live seasonality evidence.
+- **Acceptance**
+  - Live or explicitly `BLOCKED` with no fake trend claims.
+  - Demand calendar remains valid offline fallback.
+
+## Task 11 — Independent judge on every draft
+
+- **Status:** `BLOCKED_BY_PRIOR` (can be reordered earlier if owner wants quality gate before more data sources)
+- **PR:** dedicated independent-QA branch
+- **Goal:** Run the independent judge model on every proposal draft before Connect PR open; reject or expand on failure.
+- **Acceptance**
+  - Deterministic fixture path + live model path classified separately.
+  - Token guard still applies; quality rejection does not open junk PRs.
+  - No merge/deploy authority.
+
+## Task 12 — Indexation / coverage signals
+
+- **Status:** `BLOCKED_BY_PRIOR` until Task 1 is `LIVE_VERIFIED`
+- **PR:** dedicated GSC coverage / URL Inspection branch
+- **Goal:** Know whether prior posts in a cluster are indexed before writing more of the same intent.
+- **Acceptance**
+  - Uses Search Console APIs already proven in Task 1 where possible.
+  - Fail closed / degrade when inspection quota or scope is missing.
+
+## Task 13 — Post-publish observation loop
+
+- **Status:** `BLOCKED_BY_PRIOR` until Tasks 1, 3, and preferably 6 exist
+- **PR:** dedicated observation-loop branch
+- **Goal:** 14 to 28 days after a human-merged post, pull GSC/GA4 deltas for that URL/query cluster and feed the next topic decision.
+- **Acceptance**
+  - Git-backed observation manifest; no CMS/DB.
+  - Truthful when data is immature (<3 day GSC lag policy still applies).
+
+## Task 14 — Image provenance / rights (optional)
+
+- **Status:** `OPTIONAL` / last
+- **PR:** dedicated image-rights branch
+- **Goal:** Only if Eve should propose real images; provenance, rights, alt text, relevance gates.
+- **Acceptance**
+  - Text drafts never blocked on missing images.
+  - No unlicensed scraping into the repo.
+
+---
+
+## Suggested near-term order (owner confirmed)
+
+1. Task 1 Search Console live  
+2. Task 2 PageSpeed live  
+3. Task 3 GSC → topic selection  
+4. Task 4 PageSpeed → QA  
+5. Then continue 5 → 14 as above  
+
+If a live probe for Task 1 or 2 fails, stop and fix credentials/scopes before any “wire into Eve” PR.
+
+## Progress log
+
+| Task | Branch / PR | Offline tests | Live class | Notes |
+| --- | --- | --- | --- | --- |
+| 1 Search Console live | | | | Credentials present 2026-08-03; not yet probed |
+| 2 PageSpeed live | | | | API key present 2026-08-03; not yet probed |
+| 3 GSC topic wiring | | | | Blocked on Task 1 |
+| 4 PSI QA wiring | | | | Blocked on Task 2 |
+| 5 Browser research | | | | |
+| 6 GA4 | | | | |
+| 7 Local Falcon | | | | |
+| 8 Business Profile | | | | |
+| 9 SERP / PAA | | | | |
+| 10 Trends | | | | |
+| 11 Independent judge | | | | |
+| 12 Indexation | | | | |
+| 13 Observation loop | | | | |
+| 14 Images | | | | |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a sequenced integration task board so Eve gains tools one at a time, with a dedicated PR and live proof before the next feature starts.

### Credential check (Search Console + PageSpeed)
Production env for `wadesplumbingandseptic-com` already contains:
- `GOOGLE_SERVICE_ACCOUNT_EMAIL` / `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
- `PAGESPEED_API_KEY`
- `SEO_AGENT_ENABLE_SEARCH_CONSOLE` / `SEO_AGENT_ENABLE_PAGESPEED`
- live-read approval vars

Values were not logged. Neither adapter is `LIVE_VERIFIED` until a redacted live probe succeeds.

### Rollout order
1. Search Console live verification
2. PageSpeed live verification
3. Wire GSC into topic selection
4. Wire PageSpeed into draft/preview QA
5. Browser research / Browserbase
6. GA4
7. Local Falcon
8. Business Profile
9. SERP / PAA API
10. Google Trends
11. Independent judge on every draft
12. Indexation / coverage
13. Post-publish observation loop
14. Image provenance (optional)

Rules: one feature per PR, offline tests first, truthful `LIVE_VERIFIED` or recorded blocker before the next task.

### Docs
- `docs/seo-agent/INTEGRATION_ROLLOUT.md`
- Phase 61 note in `IMPLEMENTATION_STATUS.md`

### Next
After merge, start **Task 1 only** (Search Console live probe) on its own branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc527-ee67-7312-924c-204c4445aab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc527-ee67-7312-924c-204c4445aab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

