### PR TITLE
fix(eve): Cron-trigger Search Console live probe

### DIFF
--- a/automation/seo-agent/src/live-probe-http.mjs
+++ b/automation/seo-agent/src/live-probe-http.mjs
@@ -44,14 +44,16 @@ export async function handleSearchConsoleLiveProbe({
 	if (!auth.ok) return auth;
 
 	const url = new URL(request.url);
-	const runId = url.searchParams.get("run_id");
+	const runId =
+		url.searchParams.get("run_id") ?? config.liveReads?.approvedRunId ?? null;
 	if (typeof runId !== "string" || !/^[a-z0-9][a-z0-9-]{2,79}$/.test(runId)) {
 		return Object.freeze({
 			ok: false,
 			status: 400,
 			body: Object.freeze({
 				error: "MALFORMED_REQUEST",
-				message: "Query parameter run_id must be a safe audit run ID.",
+				message:
+					"Provide run_id as a query parameter or set SEO_AGENT_LIVE_READS_APPROVED_RUN_ID.",
 			}),
 		});
 	}

--- a/automation/seo-agent/tests/live-probe-http.test.mjs
+++ b/automation/seo-agent/tests/live-probe-http.test.mjs
@@ -82,6 +82,48 @@ test("Search Console live probe route returns LIVE_VERIFIED for an approved run"
 	);
 });
 
+test("Search Console live probe can use the approved run ID when query is omitted", async () => {
+	const runId = "search-console-live-2026-08-03";
+	const config = loadConfig({
+		SEO_AGENT_ENV: "production",
+		SEO_AGENT_ENABLE_SEARCH_CONSOLE: "true",
+		SEO_AGENT_LIVE_READS_APPROVED: "true",
+		SEO_AGENT_LIVE_READS_APPROVED_RUN_ID: runId,
+	});
+	const result = await handleSearchConsoleLiveProbe({
+		request: {
+			url: "https://example.test/_internal/eve/api/live-probe/search-console",
+			headers: {
+				get(name) {
+					return name.toLowerCase() === "authorization"
+						? `Bearer ${cronSecret}`
+						: null;
+				},
+			},
+		},
+		config,
+		cronSecret,
+		registry: {
+			search_console: {
+				async probe({ runId: requested }) {
+					assert.equal(requested, runId);
+					return makeEvidence({
+						runId,
+						source: "search-console",
+						scope: "site-access",
+						classification: "LIVE_VERIFIED",
+						sourceUrlOrTool:
+							"https://www.googleapis.com/webmasters/v3/sites",
+						payload: { sites: [] },
+					});
+				},
+			},
+		},
+	});
+	assert.equal(result.ok, true);
+	assert.equal(result.body.run_id, runId);
+});
+
 test("Search Console live probe route refuses mismatched run IDs", async () => {
 	const config = loadConfig({
 		SEO_AGENT_ENV: "production",

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
 	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"crons": [
+		{
+			"path": "/_internal/eve/api/live-probe/search-console",
+			"schedule": "0 0 1 1 *"
+		}
+	],
 	"services": {
 		"site": {
 			"root": ".",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables the Task 1 live Search Console proof by registering a Vercel Cron path that injects `CRON_SECRET` for `GET /_internal/eve/api/live-probe/search-console`.

Local CLI cannot read Sensitive Production secrets, and the Eve audit Cron stops earlier on missing Git snapshot. This Cron path exercises Search Console directly inside Production.

### Changes
- `vercel.json` Cron: `/_internal/eve/api/live-probe/search-console` (`0 0 1 1 *`, manual trigger only)
- Live probe falls back to `SEO_AGENT_LIVE_READS_APPROVED_RUN_ID` when `run_id` is omitted
- Fixture coverage for that fallback

### After merge
1. Redeploy Production so the Cron registers and env is loaded
2. `vercel crons run /_internal/eve/api/live-probe/search-console`
3. Expect `LIVE_VERIFIED` or a truthful Search Console failure
4. Reset live-read approval and `SEO_AGENT_FORCE_OBSERVE`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc527-ee67-7312-924c-204c4445aab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc527-ee67-7312-924c-204c4445aab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

