### PR TITLE
docs(eve): Sanitize IMPLEMENTATION_STATUS after #103 squash

### DIFF
--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -1,6 +1,5 @@
 # Eve SEO Agent Implementation Status
 
-<<<<<<< HEAD
 ## Phase 66: Task 2 PageSpeed LIVE_VERIFIED (2026-08-03)
 
 - State: COMPLETE for Task 2 live proof (`LIVE_VERIFIED`).
@@ -52,17 +51,15 @@
 - After a `LIVE_VERIFIED` response: reset `SEO_AGENT_LIVE_READS_APPROVED=false` and remove the approved run ID. Do not start Task 2 until that proof exists.
 - Out of scope (Task 3): wiring GSC into topic selection.
 - Next exact action: human merge/deploy this PR, then run the Production live-probe URL once and record the redacted classification.
-=======
+
 ## Phase 54: Live Connect Draft PR Proof (2026-08-03)
 
-- State: LIVE_VERIFIED for Cron → Vercel Connect → draft PR. Not a fixture result.
+- State: LIVE_VERIFIED for Cron → Vercel Connect → draft PR. Not a fixture result. Publisher reuses an existing draft branch or open draft PR on GitHub create `422` (`#103` merged).
 - Connect: team `wades-web-dev` connector `github/wadesplumbingandseptic-com` (`scl_FVfVjQbQtfeqYXRbfvxCrA`), GitHub App `gitwadesplumbingandseptic-com`, installation `150943643` on `byronwade`, attached to project `wadesplumbingandseptic-com` for Production and Preview.
 - Production health before proof: `mode: propose`, `ready: true`, `mutation_kill_switch: false`.
 - Commands: `vercel crons run "/eve/v1/cron/mztlWjGEvDDzWJTu64vs_D4R0wSVHIOJ1Cxo9o6r_VI" --project wadesplumbingandseptic-com --scope wades-web-dev` at `2026-08-03T12:50:08.094Z`. Agent Run `wrun_41KZ3TS9TB0GQPT2K1YEX9SMHQ` completed in `30.7s` on deployment `dpl_3ZTdJevhxmAQwp7xv1vqW5zfTVF9`.
 - Draft PR: [#102](https://github.com/byronwade/wadesplumbingandseptic.com/pull/102) opened by `gitwadesplumbingandseptic-com[bot]` on `eve/seo/2026-08-03-home-plumbing-hosting-checklist-2026-08-03` with `content/posts/home-plumbing-hosting-checklist-2026-08-03.md`. Draft only; no merge and no `main` write.
-- Earlier same-day failure: Agent Run `wrun_41KZ3TN9860GSFRYR8Q3EV14EK` hit GitHub HTTP `422` because the interim manual `eve/seo/...` branch already existed. After that branch was removed, the second Cron succeeded. Follow-up code reuses an existing draft branch or open draft PR on create `422` so same-day retries do not fail closed.
-- Next exact action: human review of PR `#102` for content; merge the idempotent publisher repair when ready.
->>>>>>> e34d2e3 (fix(eve): Reuse existing Connect draft branch/PR on GitHub 422)
+- Earlier same-day failure: Agent Run `wrun_41KZ3TN9860GSFRYR8Q3EV14EK` hit GitHub HTTP `422` because the interim manual `eve/seo/...` branch already existed. After that branch was removed, the second Cron succeeded.
 
 ## Phase 53: Remove Draft-PR Safety Blocks (2026-08-03)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`#103` squash merge reintroduced conflict markers into `docs/seo-agent/IMPLEMENTATION_STATUS.md` on `main`.

## Fix

- Restore clean Phase 66 to 62 status from `#111`
- Keep Phase 54 Connect draft proof notes with `#103` publisher idempotency callout
- No runtime code changes (`publishing.mjs` from `#103` stays)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc527-ee67-7312-924c-204c4445aab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc527-ee67-7312-924c-204c4445aab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

