### PR TITLE
docs(eve): Note Task 5 post-reset Production redeploy id

### DIFF
--- a/docs/seo-agent/IMPLEMENTATION_STATUS.md
+++ b/docs/seo-agent/IMPLEMENTATION_STATUS.md
@@ -9,7 +9,7 @@
   - `2026-08-03T16:11:19.604Z` request `pvg9f-1785773479604-875726474167` → `200`
   - `2026-08-03T16:11:24.010Z` request `jxqqx-1785773484010-820345f8e44f` → `200`
   - `2026-08-03T16:11:28.231Z` request `4klwv-1785773488231-7505d212de28` → `200`
-- Cleanup: `SEO_AGENT_LIVE_READS_APPROVED=false`, approved run ID removed, `SEO_AGENT_BROWSER_RESEARCH_ENABLED=false`, Production redeploy after reset. Standing propose may still auto-enable research for Cron proposal runs.
+- Cleanup: `SEO_AGENT_LIVE_READS_APPROVED=false`, approved run ID removed, `SEO_AGENT_BROWSER_RESEARCH_ENABLED=false`, Production redeploy `dpl_7AotW1u2guL5ZJKEAc5TjiTyipm1` after reset. Standing propose may still auto-enable research for Cron proposal runs.
 - Browserbase: still `BLOCKED_MISSING_CREDENTIALS` (no Production API key/project id).
 - Next exact action: start Task 6 (GA4) only if GA4 credentials/property access are reviewed; otherwise record `BLOCKED_MISSING_CREDENTIALS` and skip to the next owned task.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Production redeploy id `dpl_7AotW1u2guL5ZJKEAc5TjiTyipm1` after Task 5 live-read flag reset. No runtime changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc527-ee67-7312-924c-204c4445aab8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc527-ee67-7312-924c-204c4445aab8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

